### PR TITLE
Added missing BuildRequires

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -17,6 +17,8 @@ BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  pkgconfig(libmkcal-qt5)
 BuildRequires:  pkgconfig(libkcalcoren-qt5)
 BuildRequires:  pkgconfig(buteosyncfw5)
+BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(signon-oauth2plugin)
 Requires: buteo-syncfw-qt5-msyncd
 Requires: mkcal-qt5
 


### PR DESCRIPTION
BuildRequires:  pkgconfig(accounts-qt5)
BuildRequires:  pkgconfig(signon-oauth2plugin)

Tested in my OBS project against sailfish:1.0.3.8 target.
https://build.merproject.org/package/show?package=buteo-sync-plugin-caldav-manual&project=home%3Atbr%3Asailfish
