### PR TITLE
[buteo-sync-plugin-caldav] Use a time range for quick syncs

### DIFF
--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -198,7 +198,7 @@ void NotebookSyncAgent::sendReportRequest()
         connect(report, SIGNAL(finished()), this, SLOT(reportRequestFinished()));
         report->getAllEvents(mServerPath, mFromDateTime, mToDateTime);
     } else {
-        fetchRemoteChanges();
+        fetchRemoteChanges(mFromDateTime, mToDateTime);
     }
 }
 
@@ -238,7 +238,7 @@ bool NotebookSyncAgent::isFinished() const
     return mFinished;
 }
 
-void NotebookSyncAgent::fetchRemoteChanges()
+void NotebookSyncAgent::fetchRemoteChanges(const QDateTime &fromDateTime, const QDateTime &toDateTime)
 {
     NOTEBOOK_FUNCTION_CALL_TRACE;
 
@@ -261,7 +261,7 @@ void NotebookSyncAgent::fetchRemoteChanges()
     if (!mStorage->deletedIncidences(&deletions, KDateTime(mChangesSinceDate), mNotebook->uid())) {
         LOG_CRITICAL("mKCal::ExtendedStorage::deletedIncidences() failed");
     }
-    report->getAllETags(mServerPath, mLocalETags, storageIncidenceList, deletions);
+    report->getAllETags(mServerPath, mLocalETags, storageIncidenceList, deletions, fromDateTime, toDateTime);
 }
 
 void NotebookSyncAgent::sendLocalChanges()

--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -86,7 +86,7 @@ private:
     void clearRequests();
     void emitFinished(int minorErrorCode, const QString &message);
 
-    void fetchRemoteChanges();
+    void fetchRemoteChanges(const QDateTime &fromDateTime, const QDateTime &toDateTime);
     bool updateIncidences(const QList<Reader::CalendarResource> &resources);
     bool deleteIncidences(const QStringList &incidenceUids);
 


### PR DESCRIPTION
Some servers (e.g Memotoo) don't emit a proper reply if we try to
fetch the etags with a defined time range. This commit is a partial
revert of 782ef9db20125f36fec4bbf78ac04a0d335debc7.
Now the client will only store events 6 months older than current date
and 12 months in the future.
