### PR TITLE
[buteo-sync-plugin-caldav] Fix QUrl creating from percent encoded string...

### DIFF
--- a/src/request.cpp
+++ b/src/request.cpp
@@ -124,7 +124,7 @@ void Request::prepareRequest(QNetworkRequest *request, const QString &requestPat
         url.setUserName(mSettings->username());
         url.setPassword(mSettings->password());
     }
-    url.setPath(requestPath);
+    url.setPath(QUrl::fromPercentEncoding(requestPath.toLatin1()));
     request->setUrl(url);
 }
 


### PR DESCRIPTION
...s

Calendar urls are currently saved in percent encoded format
when passed them in this format to QUrl::setPath a recoding
can happen(Tolerant mode is the default) breaking the original
server path, so we decode them first.
