### PR TITLE
Let Reader class parse all retrieved iCalData

### DIFF
--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -682,8 +682,7 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
             LOG_DEBUG("Ignore incidence already deleted locally:" << resource.href);
             continue;
         }
-        KCalCore::ICalFormat iCalFormat;
-        KCalCore::Incidence::Ptr newIncidence = iCalFormat.fromString(resource.iCalData);
+        const KCalCore::Incidence::Ptr &newIncidence = resource.incidence;
         if (newIncidence.isNull()) {
             continue;
         }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -27,6 +27,8 @@
 #include <QUrl>
 #include <QXmlStreamReader>
 
+#include <icalformat.h>
+
 #include <LogMacros.h>
 
 Reader::Reader(QObject *parent)
@@ -92,6 +94,10 @@ void Reader::readResponse()
     if (resource.href.isEmpty()) {
         LOG_WARNING("Ignoring received calendar object data, is missing href value");
         return;
+    }
+    if (!resource.iCalData.isEmpty()) {
+        KCalCore::ICalFormat iCalFormat;
+        resource.incidence = iCalFormat.fromString(resource.iCalData);
     }
     LOG_DEBUG(QUrl::fromPercentEncoding(resource.href.toLatin1()));
     mResults.insert(QUrl::fromPercentEncoding(resource.href.toLatin1()), resource);

--- a/src/reader.h
+++ b/src/reader.h
@@ -27,6 +27,8 @@
 #include <QObject>
 #include <QHash>
 
+#include <incidence.h>
+
 class QXmlStreamReader;
 
 class Reader : public QObject
@@ -38,6 +40,7 @@ public:
         QString etag;
         QString status;
         QString iCalData;
+        KCalCore::Incidence::Ptr incidence;
     };
 
     explicit Reader(QObject *parent = 0);


### PR DESCRIPTION
For some servers (e.g. Owncloud), the uid of an incidence cannot be derived from its uri. Therefore we need to parse each retrieved incidence to be able to extract its true uid.

This is another preparatory pull request for improving Owncloud support. I am not quite sure if what I am doing here is the best solution as it increases the memory consumption of the retrieved resources.
Alternatives would be to parse iCalData and only store the uid or to only store the incidence and throw the string representation away. However, the parsed incidence is needed again when we apply changes locally and the string representation is stored in the sync database in case of a remote modification. Thus both alternatives would involve additional serializations or deserializations of some incidences. Assuming that parsing iCalData is relatively expensive, I decided to trade memory for speed ..
