### PR TITLE
Fix ICal data encoding to match the Content-Type header

### DIFF
--- a/src/put.cpp
+++ b/src/put.cpp
@@ -66,7 +66,7 @@ void Put::updateEvent(const QString &serverPath, KCalCore::Incidence::Ptr incide
     request.setHeader(QNetworkRequest::ContentTypeHeader, "text/calendar; charset=utf-8");
 
     QBuffer *buffer = new QBuffer(this);
-    buffer->setData(data.toLatin1());
+    buffer->setData(data.toUtf8());
     QNetworkReply *reply = mNAManager->sendCustomRequest(request, REQUEST_TYPE.toLatin1(), buffer);
     reply->setProperty(PROP_INCIDENCE_UID, incidence->uid());
     debugRequest(request, data);
@@ -95,7 +95,7 @@ void Put::createEvent(const QString &serverPath, KCalCore::Incidence::Ptr incide
     request.setHeader(QNetworkRequest::ContentTypeHeader, "text/calendar; charset=utf-8");
 
     QBuffer *buffer = new QBuffer(this);
-    buffer->setData(ical.toLatin1());
+    buffer->setData(ical.toUtf8());
     QNetworkReply *reply = mNAManager->sendCustomRequest(request, REQUEST_TYPE.toLatin1(), buffer);
     reply->setProperty(PROP_INCIDENCE_UID, incidence->uid());
     debugRequest(request, ical);


### PR DESCRIPTION
Some CalDAV servers (SOGo at least) seem a bit picky
about the data encoding and if the ICal data encoding
does not match the one specified in the Content-Type
HTTP header then the creation or update is rejected.
Bug is exhibited when any ICal property contains
non-ASCII characters.

Testing was performed with the latest SOGo stable
release.
