### PR TITLE
Do not use Reader::hrefToUid to determine the UID of an incidence

### DIFF
--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -104,6 +104,7 @@ private:
     KCalCore::Incidence::List mCalendarIncidencesBeforeSync;
     QSet<QString> mLocalDeletedUids;
     QList<Reader::CalendarResource> mReceivedCalendarResources;
+    QSet<QString> mReceivedUids;
     QStringList mNewRemoteIncidenceIds;
     QHash<QString,QString> mModifiedIncidenceICalData;
     QHash<QString,QString> mLocalETags;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -58,20 +58,6 @@ const QHash<QString, Reader::CalendarResource>& Reader::results() const
     return mResults;
 }
 
-QString Reader::hrefToUid(const QString &href)
-{
-    QString result = href;
-    int slash = result.lastIndexOf('/');
-    if (slash >= 0 && slash+1 < result.length()) {
-        result = result.mid(slash + 1);
-    }
-    int ext = result.lastIndexOf(".ics");
-    if (ext >= 0) {
-        result = result.mid(0, ext);
-    }
-    return result;
-}
-
 void Reader::readMultiStatus()
 {
     while (mReader->readNextStartElement()) {

--- a/src/reader.h
+++ b/src/reader.h
@@ -49,8 +49,6 @@ public:
     void read(const QByteArray &data);
     const QHash<QString, CalendarResource>& results() const;
 
-    static QString hrefToUid(const QString &href);
-
 private:
     void readMultiStatus();
     void readResponse();


### PR DESCRIPTION
For some servers (e.g. Owncloud), the uid of an incidence cannot be derived from its uri. As a consequence, remote incidences are not correctly mapped to local incidences when Reader::hrefToUid is used.
