### PR TITLE
Use correct URI for DELETE requests.

### DIFF
--- a/src/delete.cpp
+++ b/src/delete.cpp
@@ -37,18 +37,12 @@ Delete::Delete(QNetworkAccessManager *manager, Settings *settings, QObject *pare
     FUNCTION_CALL_TRACE;
 }
 
-void Delete::deleteEvent(const QString &serverPath, KCalCore::Incidence::Ptr incidence)
+void Delete::deleteEvent(const QString &href)
 {
     FUNCTION_CALL_TRACE;
 
-    QString uri = resourceUriForIncidence(incidence);
-    if (uri.isEmpty()) {
-        finishedWithError(Buteo::SyncResults::INTERNAL_ERROR,
-                          QString("DELETE not sent, cannot get uri for incidence %1").arg(incidence->uid()));
-        return;
-    }
     QNetworkRequest request;
-    prepareRequest(&request, serverPath + uri);
+    prepareRequest(&request, href);
     QNetworkReply *reply = mNAManager->sendCustomRequest(request, REQUEST_TYPE.toLatin1());
     debugRequest(request, QStringLiteral(""));
     connect(reply, SIGNAL(finished()), this, SLOT(requestFinished()));
@@ -74,17 +68,4 @@ void Delete::requestFinished()
 
     finishedWithReplyResult(reply->error());
     reply->deleteLater();
-}
-
-QString Delete::resourceUriForIncidence(KCalCore::Incidence::Ptr incidence)
-{
-    QString uri = incidence->customProperty("buteo", "uri");
-    if (!uri.isEmpty()) {
-        return uri.split("/", QString::SkipEmptyParts).last();
-    }
-    QString path = incidence->uid();
-    if (!path.isEmpty()) {
-        path += VCalExtension;
-    }
-    return path;
 }

--- a/src/delete.h
+++ b/src/delete.h
@@ -42,13 +42,11 @@ class Delete : public Request
 public:
     explicit Delete(QNetworkAccessManager *manager, Settings *settings, QObject *parent = 0);
 
-    void deleteEvent(const QString &serverPath, KCalCore::Incidence::Ptr incidence);
+    void deleteEvent(const QString &href);
 
 private Q_SLOTS:
     void requestFinished();
 
-private:
-    QString resourceUriForIncidence(KCalCore::Incidence::Ptr incidence);
 };
 
 #endif // DELETE_H


### PR DESCRIPTION
We cannot use incidence.customProperty("buteo", "uri") since the storage backend removes all custom properties from deleted incidences. We also cannot use its UID as there is, in general, no correlation between the UID of an incidence and its URI on the server.

However, we only DELETE an incidence if it is still on the server, and all locally deleted incidences which are still on the server are downloaded by fetchRemoteChanges. Therefore we can determine the URI by searching mReceivedCalendarResources for the deleted incidence.
