### PR TITLE
Ensure uris and etags are up to date

### DIFF
--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -79,6 +79,7 @@ signals:
 
 private slots:
     void reportRequestFinished();
+    void additionalReportRequestFinished();
     void nonReportRequestFinished();
     void processETags();
 private:
@@ -91,6 +92,7 @@ private:
     bool deleteIncidences(const QStringList &incidenceUids);
 
     void sendLocalChanges();
+    void finalizeSendingLocalChanges();
     bool loadLocalChanges(const QDateTime &fromDate,
                           KCalCore::Incidence::List *inserted,
                           KCalCore::Incidence::List *modified,
@@ -102,6 +104,8 @@ private:
                                KCalCore::Incidence::List *deleted);
 
     KCalCore::Incidence::List mCalendarIncidencesBeforeSync;
+    KCalCore::Incidence::List mLocallyInsertedIncidences;
+    KCalCore::Incidence::List mLocallyModifiedIncidences;
     QSet<QString> mLocalDeletedUids;
     QList<Reader::CalendarResource> mReceivedCalendarResources;
     QSet<QString> mReceivedUids;


### PR DESCRIPTION
This pull request introduces a `finalizeSendingLocalChanges` method which is called after all local changes have been sent to the server. It does the following:
- Check for all local insertions and modifications if an ETag has been received for the corresponding PUT request. Not all servers (e.g. Owncloud) do this. In fact, the standard (RFC 4791, section 5.3.4.) only encourages doing so,  'if the stored calendar object resource is equivalent by octet equality to the calendar object resource submitted in the body of the PUT request'.
  
  If no ETag has been received, the incidence is reloaded from the server with an additional multiget request. (If the ETag is not updated, all local changes until the next sync will be overwritten as the incidence will always be detected as having changed on the server. - We receive the whole incidence and not only the ETag since the server might modify the incidence before storing it.)
- For locally inserted incidences the `uri` custom property is set to ensure that it can be identified by `processETags` during the next sync. Unfortunately, there seems to be no way to modfiy an incidence without changing its modification time. Therefore we have to add the incidence to the modifications table of mDatabase to ensure that the change of the `uri` property is not picked up as a local change during the next sync.
