### PR TITLE
[caldav] Improve discovery of local deletions

### DIFF
--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -96,16 +96,18 @@ private:
     bool loadLocalChanges(const QDateTime &fromDate,
                           KCalCore::Incidence::List *inserted,
                           KCalCore::Incidence::List *modified,
-                          KCalCore::Incidence::List *deleted);
+                          QStringList *deleted);
     bool discardRemoteChanges(KCalCore::Incidence::List *localInserted,
                               KCalCore::Incidence::List *localModified,
-                              KCalCore::Incidence::List *localDeleted);
+                              QStringList *localDeleted);
     int removeCommonIncidences(KCalCore::Incidence::List *inserted,
-                               KCalCore::Incidence::List *deleted);
+                               QStringList *deleted);
 
     KCalCore::Incidence::List mCalendarIncidencesBeforeSync;
+    KCalCore::Incidence::List mStorageIncidenceList;
     KCalCore::Incidence::List mLocallyInsertedIncidences;
     KCalCore::Incidence::List mLocallyModifiedIncidences;
+    QSet<QString> mStorageUids;
     QSet<QString> mLocalDeletedUids;
     QList<Reader::CalendarResource> mReceivedCalendarResources;
     QSet<QString> mReceivedUids;


### PR DESCRIPTION
Locally deleted incidences which have been received from the server during the last sync are not reported by `mStorage->deletedIncidences`. This is due to the fact that such incidences have a creation date after
the start date of the last sync. `deletedIncidences` only reports incidences which have been deleted after a given date but have been created before this date. As a result, the incidences in question are retrieved as new incidences from the server instead of being deleted on the server.

To fix this problem, go through the list of remote additions during the last sync and look for uids which have disappeared from the local storage. These are then added to the list of local deletions.

To implement this, I had to change the list of local deletions from `KCalCore::Incidence::List` to `QStringList` because the additions table of mDatabase only contains the uids of the last remote additions not the complete incidences. 
