### PR TITLE
[caldav] Copy recurrence properties during update

### DIFF
--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -416,7 +416,7 @@ void CalDavClient::start()
         getSyncDateRange(mSyncStartTime, &fromDateTime, &toDateTime);
         notebooks = mStorage->notebooks();
     }
-    LOG_DEBUG("\n\n++++++++++++++ mSyncStartTime:" << mSyncStartTime << "LAST SYNC:" << lastSyncTime());
+    LOG_DEBUG("++++++++++++++ mSyncStartTime:" << mSyncStartTime << "LAST SYNC:" << lastSyncTime());
 
     Q_FOREACH (const Settings::CalendarInfo &calendarInfo, allCalendarInfo) {
         mKCal::Notebook::Ptr existingNotebook;


### PR DESCRIPTION
This commit ensures that recurrence information is correctly copied
into existing incidences during update.