### PR TITLE
[buteo-sync-plugin-caldav] Examine recurrence when determining change delta

### DIFF
--- a/src/incidencehandler.cpp
+++ b/src/incidencehandler.cpp
@@ -123,6 +123,9 @@ bool IncidenceHandler::copiedPropertiesAreEqual(const KCalCore::Incidence::Ptr &
     normalizePersonEmail(&personB);
     RETURN_FALSE_IF_NOT_EQUAL_CUSTOM(personA != personB, "organizer", (personA.fullName() + " " + personB.fullName()));
 
+    // check recurrence information
+    RETURN_FALSE_IF_NOT_EQUAL_CUSTOM(*(a->recurrence()) != *(b->recurrence()), "recurrence", "...");
+
     switch (a->type()) {
     case KCalCore::IncidenceBase::TypeEvent:
         if (!eventsEqual(a.staticCast<KCalCore::Event>(), b.staticCast<KCalCore::Event>())) {


### PR DESCRIPTION
This commit ensures that we do not discard events which have only
changed via recurrence information from the upsync delta.