### PR TITLE
[buteo-sync-plugin-caldav] Prevent dtEnd data from being lost for all-da...

### DIFF
--- a/src/incidencehandler.cpp
+++ b/src/incidencehandler.cpp
@@ -229,7 +229,6 @@ void IncidenceHandler::copyIncidenceProperties(KCalCore::Incidence::Ptr dest, co
         KCalCore::Event::Ptr destEvent = dest.staticCast<KCalCore::Event>();
         KCalCore::Event::Ptr srcEvent = src.staticCast<KCalCore::Event>();
         COPY_IF_NOT_EQUAL(destEvent, srcEvent, dtEnd(), setDtEnd);
-        COPY_IF_NOT_EQUAL(destEvent, srcEvent, hasEndDate(), setHasEndDate);
         COPY_IF_NOT_EQUAL(destEvent, srcEvent, transparency(), setTransparency);
     }
 
@@ -368,7 +367,6 @@ KCalCore::Incidence::Ptr IncidenceHandler::incidenceToExport(KCalCore::Incidence
             // all-day event, so remove the DTEND before upsyncing.
             LOG_DEBUG("Remove DTEND from" << incidence->uid());
             event->setDtEnd(KDateTime());
-            event->setHasEndDate(false);
         } else if (event->hasEndDate()) {
             KDateTime dt = event->dtEnd();
             // Event::dtEnd() is inclusive, but DTEND in iCalendar format is exclusive.


### PR DESCRIPTION
...y events

Don't copy the hasEndDate property in copyIncidenceProperties().
If the dtStart == dtEnd, calling setHasEndDate() causes the previous
setDtEnd() value to be lost and the dtEnd just becomes an invalid
KDateTime.

It's not necessary to copy hasEndDate anyway since internally this
will be set when setDtEnd() is called. For this reason, also remove
the call to setHasEndDate() in incidenceToExport(), since it already
calls setDtEnd().