### PR TITLE
[caldav] Remove libsocialcache usage. Contributes to MER#916

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -19,7 +19,6 @@ BuildRequires:  pkgconfig(libkcalcoren-qt5)
 BuildRequires:  pkgconfig(buteosyncfw5)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(signon-oauth2plugin)
-BuildRequires:  pkgconfig(socialcache) >= 0.0.33
 Requires: buteo-syncfw-qt5-msyncd
 Requires: mkcal-qt5
 

--- a/src/caldavclient.h
+++ b/src/caldavclient.h
@@ -42,7 +42,6 @@
 #include <Accounts/Manager>
 
 class QNetworkAccessManager;
-class CalDavCalendarDatabase;
 class Request;
 
 /*
@@ -137,7 +136,6 @@ public Q_SLOTS:
 private Q_SLOTS:
     void start();
     void authenticationError();
-    void databaseWriteStatusChanged();
     void notebookSyncFinished(int errorCode, const QString &errorString);
 
 private:
@@ -149,6 +147,7 @@ private:
     void clearAgents();
     bool deleteNotebook(int accountId, mKCal::ExtendedCalendar::Ptr calendar, mKCal::ExtendedStorage::Ptr storage, mKCal::Notebook::Ptr notebook);
     void deleteNotebooksForAccount(int accountId, mKCal::ExtendedCalendar::Ptr calendar, mKCal::ExtendedStorage::Ptr storage);
+    bool cleanSyncRequired(int accountId);
     void getSyncDateRange(const QDateTime &sourceDate, QDateTime *fromDateTime, QDateTime *toDateTime);
     QList<Settings::CalendarInfo> loadCalendars(Accounts::Account *account, Accounts::Service srv) const;
 
@@ -161,7 +160,6 @@ private:
     QNetworkAccessManager*      mNAManager;
     Accounts::Manager*          mManager;
     AuthHandler*                mAuth;
-    CalDavCalendarDatabase*     mDatabase;
     mKCal::ExtendedCalendar::Ptr mCalendar;
     mKCal::ExtendedStorage::Ptr mStorage;
     Buteo::SyncResults          mResults;

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -30,8 +30,6 @@
 #include "delete.h"
 #include "reader.h"
 
-#include <caldavcalendardatabase.h>
-
 #include <LogMacros.h>
 #include <SyncResults.h>
 
@@ -43,29 +41,113 @@
 #include <journal.h>
 #include <attendee.h>
 
+#include <QUuid>
 #include <QDebug>
 
 
 #define NOTEBOOK_FUNCTION_CALL_TRACE FUNCTION_CALL_TRACE(QString("%1 %2").arg(Q_FUNC_INFO).arg(mNotebook ? mNotebook->account() : ""))
 
+namespace {
+    // mKCal deletes custom properties of deleted incidences.
+    // This is problematic for sync, as we need some fields
+    // (resource URI and ETAG) in order to sync properly.
+    // Hence, we abuse the COMMENTS field of the incidence.
+    QString incidenceHrefUri(KCalCore::Incidence::Ptr incidence, const QString &remoteCalendarPath = QString(), bool *uriNeedsFilling = 0)
+    {
+        const QStringList &comments(incidence->comments());
+        Q_FOREACH (const QString &comment, comments) {
+            if (comment.startsWith("buteo:caldav:uri:")) {
+                return comment.mid(17);
+            }
+        }
+        if (uriNeedsFilling) {
+            // must be a newly locally-added event, with uri comment not yet set.
+            // return the value which we should upload the event to.
+            *uriNeedsFilling = true;
+            return remoteCalendarPath + incidence->uid() + ".ics";
+        }
+        LOG_WARNING("Returning empty uri for:" << incidence->uid() << incidence->recurrenceId().toString());
+        return QString();
+    }
+    void setIncidenceHrefUri(KCalCore::Incidence::Ptr incidence, const QString &hrefUri)
+    {
+        const QStringList &comments(incidence->comments());
+        Q_FOREACH (const QString &comment, comments) {
+            if (comment.startsWith("buteo:caldav:uri:")) {
+                incidence->removeComment(comment);
+                break;
+            }
+        }
+        incidence->addComment(QStringLiteral("buteo:caldav:uri:%1").arg(hrefUri));
+    }
+    int findIncidenceMatchingHrefUri(KCalCore::Incidence::List incidences, const QString &hrefUri)
+    {
+        for (int i = 0; i < incidences.size(); ++i) {
+            if (incidenceHrefUri(incidences[i]) == hrefUri) {
+                return i;
+            }
+        }
+        return -1;
+    }
+    QString incidenceETag(KCalCore::Incidence::Ptr incidence)
+    {
+        const QStringList &comments(incidence->comments());
+        Q_FOREACH (const QString &comment, comments) {
+            if (comment.startsWith("buteo:caldav:etag:")) {
+                return comment.mid(18);
+            }
+        }
+        return QString();
+    }
+    void setIncidenceETag(KCalCore::Incidence::Ptr incidence, const QString &etag)
+    {
+        const QStringList &comments(incidence->comments());
+        Q_FOREACH (const QString &comment, comments) {
+            if (comment.startsWith("buteo:caldav:etag:")) {
+                incidence->removeComment(comment);
+                break;
+            }
+        }
+        incidence->addComment(QStringLiteral("buteo:caldav:etag:%1").arg(etag));
+    }
+
+    void uniteIncidenceLists(const KCalCore::Incidence::List &first, KCalCore::Incidence::List *second)
+    {
+        int originalSecondSize = second->size();
+        bool foundMatch = false;
+        Q_FOREACH (KCalCore::Incidence::Ptr inc, first) {
+            foundMatch = false;
+            for (int i = 0; i < originalSecondSize; ++i) {
+                if (inc->uid() == second->at(i)->uid() && inc->recurrenceId() == second->at(i)->recurrenceId()) {
+                    // found a match
+                    foundMatch = true;
+                    break;
+                }
+            }
+            if (!foundMatch) {
+                second->append(inc);
+            }
+        }
+    }
+}
+
+
 NotebookSyncAgent::NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
                                      mKCal::ExtendedStorage::Ptr storage,
-                                     CalDavCalendarDatabase *database,
                                      QNetworkAccessManager *networkAccessManager,
                                      Settings *settings,
-                                     const QString &calendarServerPath,
+                                     const QString &remoteCalendarPath,
                                      QObject *parent)
     : QObject(parent)
-    , mNAManager(networkAccessManager)
-    , mDatabase(database)
+    , mNetworkManager(networkAccessManager)
     , mSettings(settings)
     , mCalendar(calendar)
     , mStorage(storage)
     , mNotebook(0)
-    , mServerPath(calendarServerPath)
+    , mRemoteCalendarPath(remoteCalendarPath)
     , mSyncMode(NoSyncMode)
-    , mFinished(false)
     , mRetriedReport(false)
+    , mFinished(false)
 {
 }
 
@@ -89,6 +171,7 @@ void NotebookSyncAgent::clearRequests()
 
     QList<Request *> requests = mRequests.toList();
     for (int i=0; i<requests.count(); i++) {
+        QObject::disconnect(requests[i], 0, this, 0);
         requests[i]->deleteLater();
     }
     mRequests.clear();
@@ -109,8 +192,7 @@ void NotebookSyncAgent::startSlowSync(const QString &calendarPath,
                                       const QString &syncProfile,
                                       const QString &color,
                                       const QDateTime &fromDateTime,
-                                      const QDateTime &toDateTime,
-                                      const QString &notebookUidToDelete)
+                                      const QDateTime &toDateTime)
 {
     NOTEBOOK_FUNCTION_CALL_TRACE;
 
@@ -126,9 +208,17 @@ void NotebookSyncAgent::startSlowSync(const QString &calendarPath,
     mColor = color;
     mFromDateTime = fromDateTime;
     mToDateTime = toDateTime;
-    mNotebookUidToDelete = notebookUidToDelete;
 
     sendReportRequest();
+}
+
+void NotebookSyncAgent::sendReportRequest()
+{
+    // must be m_syncMode = SlowSync.
+    Report *report = new Report(mNetworkManager, mSettings);
+    mRequests.insert(report);
+    connect(report, SIGNAL(finished()), this, SLOT(reportRequestFinished()));
+    report->getAllEvents(mRemoteCalendarPath, mFromDateTime, mToDateTime);
 }
 
 /*
@@ -145,7 +235,6 @@ void NotebookSyncAgent::startSlowSync(const QString &calendarPath,
  */
 void NotebookSyncAgent::startQuickSync(mKCal::Notebook::Ptr notebook,
                                        const QDateTime &changesSinceDate,
-                                       const KCalCore::Incidence::List &allCalendarIncidences,
                                        const QDateTime &fromDateTime,
                                        const QDateTime &toDateTime)
 {
@@ -157,79 +246,468 @@ void NotebookSyncAgent::startQuickSync(mKCal::Notebook::Ptr notebook,
 
     mSyncMode = QuickSync;
     mNotebook = notebook;
-    mCalendarIncidencesBeforeSync = allCalendarIncidences;
     mChangesSinceDate = changesSinceDate;
     mFromDateTime = fromDateTime;
     mToDateTime = toDateTime;
 
-    bool ok = false;
-    mLocalETags = mDatabase->eTags(mNotebook->uid(), &ok);
-    if (!ok) {
-        emitFinished(Buteo::SyncResults::DATABASE_FAILURE, QString("Unable to load etags for notebook: %1").arg(mNotebook->uid()));
-        return;
-    }
-
-    // Incidences must be loaded with ExtendedStorage::allIncidences() rather than
-    // ExtendedCalendar::incidences(), because the latter will load incidences from all
-    // notebooks, rather than just the one for this report.
-    // Note that storage incidence references cannot be used with ExtendedCalendar::deleteEvent()
-    // etc. Those methods only work for references created by ExtendedCalendar.
-    if (!mStorage->allIncidences(&mStorageIncidenceList, mNotebook->uid())) {
-        emitFinished(Buteo::SyncResults::DATABASE_FAILURE, QString("Unable to load storage incidences for notebook: %1").arg(mNotebook->uid()));
-        return;
-    }
-
-    mStorageIds.clear();
-    Q_FOREACH(const KCalCore::Incidence::Ptr &incidence, mStorageIncidenceList) {
-        mStorageIds.insert(KCalId(incidence));
-    }
-
-    LOG_DEBUG("Loaded" << mStorageIds.size() << "incidences from storage for notebook:" << mNotebook->uid());
-    sendReportRequest();
+    fetchRemoteChanges(mFromDateTime, mToDateTime);
 }
 
-void NotebookSyncAgent::sendReportRequest()
+void NotebookSyncAgent::fetchRemoteChanges(const QDateTime &fromDateTime, const QDateTime &toDateTime)
 {
-    if (mSyncMode == SlowSync) {
-        Report *report = new Report(mNAManager, mSettings);
-        mRequests.insert(report);
-        connect(report, SIGNAL(finished()), this, SLOT(reportRequestFinished()));
-        report->getAllEvents(mServerPath, mFromDateTime, mToDateTime);
-    } else {
-        fetchRemoteChanges(mFromDateTime, mToDateTime);
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    // must be m_syncMode = QuickSync.
+    Report *report = new Report(mNetworkManager, mSettings);
+    mRequests.insert(report);
+    connect(report, SIGNAL(finished()), this, SLOT(processETags()));
+    report->getAllETags(mRemoteCalendarPath, fromDateTime, toDateTime);
+}
+
+void NotebookSyncAgent::reportRequestFinished()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    Report *report = qobject_cast<Report*>(sender());
+    mRequests.remove(report);
+    report->deleteLater();
+
+    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
+        if (mPossibleLocalModificationIncidenceIds.isEmpty()) {
+            // every received resource was from m_remoteAdditions or m_remoteModifications.
+            mReceivedCalendarResources = report->receivedCalendarResources().values();
+        } else {
+            // From the received resources, some will have been fetched so that we can perform a more detailed
+            // per-event delta calculation (ie, the "possible" local modifications).
+            // We can discard any incidence in the m_localModifications list which is not significantly
+            // different to the incidence fetched from the remote server.
+            // In either case, we will remove that resource from the receivedResources list because
+            // we don't want to store the remote version of it (instead we probably want to upsync the local mod).
+            int originalLocalModificationsCount = mLocalModifications.size(), discardedLocalModifications = 0;
+            QMultiHash<QString, Reader::CalendarResource> receivedResources = report->receivedCalendarResources();
+            Q_FOREACH (const QString &hrefUri, receivedResources.keys()) {
+                QList<Reader::CalendarResource> resources = receivedResources.values(hrefUri);
+                if (mPossibleLocalModificationIncidenceIds.contains(hrefUri)) {
+                    // this resource was fetched so that we could perform a field-by-field delta detection
+                    // just in case the only change was the ETAG/URI value (due to previous sync).
+                    removePossibleLocalModificationIfIdentical(hrefUri,
+                                                               mPossibleLocalModificationIncidenceIds.values(hrefUri),
+                                                               resources,
+                                                               &mLocalModifications);
+                } else {
+                    // these were resources fetched from m_remoteAdditions or m_remoteModifications
+                    mReceivedCalendarResources.append(resources);
+                }
+            }
+            discardedLocalModifications = originalLocalModificationsCount - mLocalModifications.size();
+            LOG_DEBUG("" << discardedLocalModifications << "out of" << originalLocalModificationsCount <<
+                      "local modifications were discarded as spurious (etag/uri update only)");
+        }
+
+        LOG_DEBUG("Report request finished: received:"
+                  << report->receivedCalendarResources().size() << "iCal blobs containing a total of"
+                  << report->receivedCalendarResources().values().count() << "incidences"
+                  << "of which" << mReceivedCalendarResources.size() << "incidences were remote additions/modifications");
+
+        if (mSyncMode == QuickSync) {
+            sendLocalChanges();
+            return;
+        }
+
+        // NOTE: we don't store the remote artifacts yet
+        // Instead, we just emit finished (for this notebook)
+        // Once ALL notebooks are finished, then we apply the remote changes.
+        // This prevents the worst partial-sync issues.
+
+    } else if (mSyncMode == SlowSync
+               && report->networkError() == QNetworkReply::AuthenticationRequiredError
+               && !mRetriedReport) {
+        // Yahoo sometimes fails the initial request with an authentication error. Let's try once more
+        LOG_WARNING("Retrying REPORT after request failed with QNetworkReply::AuthenticationRequiredError");
+        mRetriedReport = true;
+        sendReportRequest();
+        return;
     }
+
+    LOG_DEBUG("emitting report request finished with result:" << report->errorCode() << report->errorString());
+    emitFinished(report->errorCode(), report->errorString());
+}
+
+void NotebookSyncAgent::processETags()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    Report *report = qobject_cast<Report*>(sender());
+    mRequests.remove(report);
+    report->deleteLater();
+
+    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
+        LOG_DEBUG("Process tags for server path" << mRemoteCalendarPath);
+        // we have a hash from resource href-uri to resource info (including etags).
+        QMultiHash<QString, Reader::CalendarResource> map = report->receivedCalendarResources();
+        QHash<QString, QString> remoteHrefUriToEtags;
+        Q_FOREACH (const QString &href, map.keys()) {
+            if (!href.contains(mRemoteCalendarPath)) {
+                LOG_WARNING("href does not contain server path:" << href << ":" << mRemoteCalendarPath);
+                emitFinished(Buteo::SyncResults::INTERNAL_ERROR, "unable to calculate remote resource uids");
+                return;
+            }
+            QList<Reader::CalendarResource> resources = map.values(href);
+            if (resources.size()) {
+                remoteHrefUriToEtags.insert(href, resources[0].etag);
+            }
+        }
+
+        // calculate the local and remote delta.
+        if (!calculateDelta(KDateTime(mChangesSinceDate),
+                            remoteHrefUriToEtags,
+                            &mLocalAdditions,
+                            &mLocalModifications,
+                            &mLocalDeletions,
+                            &mRemoteAdditions,
+                            &mRemoteModifications,
+                            &mRemoteDeletions)) {
+            emitFinished(Buteo::SyncResults::INTERNAL_ERROR, "unable to calculate sync delta");
+            return;
+        }
+
+        // Note that due to the fact that we update the ETAG and URI data in locally
+        // upsynced events during sync, those incidences will be reported as modified
+        // during the next sync cycle (even though the only changes may have been
+        // that ETAG+URI change).  Hence, we need to fetch all of those again, and
+        // then manually check equivalence (ignoring etag+uri value) with remote copy.
+        QStringList fetchPossiblyLocallyModifiedIncidenceHrefUris;
+        Q_FOREACH (KCalCore::Incidence::Ptr possiblyModified, mLocalModifications) {
+            QString pmiHrefUri = incidenceHrefUri(possiblyModified);
+            if (pmiHrefUri.isEmpty()) {
+                // this was a modification reported to a previously partially-synced event.
+                // we always treat this as a "definite" local modification.
+            } else if (!fetchPossiblyLocallyModifiedIncidenceHrefUris.contains(pmiHrefUri)) {
+                // this was a modification reported to a successfully synced event.
+                // we always treat this as a "possible" local modification.
+                // hence, we reload from remote and perform field-by-field comparison.
+                fetchPossiblyLocallyModifiedIncidenceHrefUris.append(pmiHrefUri);
+            }
+        }
+
+        // fetch updated and new items full data if required.
+        QStringList fetchRemoteHrefUris = mRemoteAdditions + mRemoteModifications + fetchPossiblyLocallyModifiedIncidenceHrefUris;
+        if (!fetchRemoteHrefUris.isEmpty()) {
+            // some incidences have changed on the server, so fetch the new details
+            Report *report = new Report(mNetworkManager, mSettings);
+            mRequests.insert(report);
+            connect(report, SIGNAL(finished()), this, SLOT(reportRequestFinished()));
+            report->multiGetEvents(mRemoteCalendarPath, fetchRemoteHrefUris);
+            return;
+        }
+
+        // no remote modifications/additions we need to fetch; just upsync local changes.
+        sendLocalChanges();
+        return;
+    } else if (report->networkError() == QNetworkReply::AuthenticationRequiredError && !mRetriedReport) {
+        // Yahoo sometimes fails the initial request with an authentication error. Let's try once more
+        LOG_WARNING("Retrying ETAG REPORT after request failed with QNetworkReply::AuthenticationRequiredError");
+        mRetriedReport = true;
+        fetchRemoteChanges(mFromDateTime, mToDateTime);
+        return;
+    }
+
+    // no remote changes to downsync, and no local changes to upsync - we're finished.
+    LOG_DEBUG("no remote changes to downsync and no local changes to upsync - finished!");
+    emitFinished(report->errorCode(), report->errorString());
+}
+
+void NotebookSyncAgent::sendLocalChanges()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    if (!mLocalAdditions.count() && !mLocalModifications.count() && !mLocalDeletions.count()) {
+        // no local changes to upsync.
+        // we're finished syncing.
+        LOG_DEBUG("no local changes to upsync - finished with notebook" << mNotebookName << mRemoteCalendarPath);
+        emitFinished(Buteo::SyncResults::NO_ERROR, QString());
+    }
+
+    QSet<QString> addModUids;
+    for (int i = 0; i < mLocalAdditions.count(); i++) {
+        if (addModUids.contains(mLocalAdditions[i]->uid())) {
+            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
+        } else {
+            addModUids.insert(mLocalAdditions[i]->uid());
+        }
+        Put *put = new Put(mNetworkManager, mSettings);
+        mRequests.insert(put);
+        connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
+        put->createEvent(mRemoteCalendarPath,
+                         constructLocalChangeIcs(mLocalAdditions[i]),
+                         mLocalAdditions[i]->uid());
+    }
+    for (int i = 0; i < mLocalModifications.count(); i++) {
+        if (addModUids.contains(mLocalModifications[i]->uid())) {
+            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
+        } else if (incidenceHrefUri(mLocalModifications[i]).isEmpty()) {
+            LOG_WARNING("error: local modification without valid url:" << mLocalModifications[i]->uid() << "->" << incidenceHrefUri(mLocalModifications[i]));
+            emitFinished(Buteo::SyncResults::INTERNAL_ERROR,
+                         "Unable to determine remote uri for modified incidence:" + mLocalModifications[i]->uid());
+            return;
+        }
+        // first, handle updates of exceptions by uploading the entire modified series.
+        if (mLocalModifications[i]->hasRecurrenceId()) {
+            addModUids.insert(mLocalModifications[i]->uid());
+            Put *put = new Put(mNetworkManager, mSettings);
+            mRequests.insert(put);
+            connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
+            put->updateEvent(mRemoteCalendarPath,
+                             constructLocalChangeIcs(mLocalModifications[i]),
+                             incidenceETag(mLocalModifications[i]),
+                             incidenceHrefUri(mLocalModifications[i]),
+                             mLocalModifications[i]->uid());
+        }
+    }
+    for (int i = 0; i < mLocalModifications.count(); i++) {
+        if (addModUids.contains(mLocalModifications[i]->uid())) {
+            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
+        }
+        // now handle updates of base incidences (which haven't otherwise already been upsynced), via direct update.
+        // TODO: is this correct?  Or should we always generate the entire series as a resource we upload?
+        // E.g. in the case where there is a pre-existing persistent exception, and the base-event gets modified,
+        // does this PUT of the modified base-event cause (unwanted) changes/deletion of the persistent exception?
+        KCalCore::ICalFormat icalFormat;
+        Put *put = new Put(mNetworkManager, mSettings);
+        mRequests.insert(put);
+        connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
+        put->updateEvent(mRemoteCalendarPath,
+                         icalFormat.toICalString(IncidenceHandler::incidenceToExport(mLocalModifications[i])),
+                         incidenceETag(mLocalModifications[i]),
+                         incidenceHrefUri(mLocalModifications[i]),
+                         mLocalModifications[i]->uid());
+    }
+
+    // For deletions, if a persistent exception is deleted we may need to do a PUT
+    // containing all of the still-existing events in the series.
+    // (Alternative is to push a STATUS:CANCELLED event?)
+    // Hence, we first need to find out if any deletion is a lone-persistent-exception deletion.
+    QMultiHash<QString, KDateTime> uidToRecurrenceIdDeletions;
+    QHash<QString, QPair<QString, QString> > uidToEtagAndUri;  // we cannot look up custom properties of deleted incidences, so cache them here.
+    Q_FOREACH (const LocalDeletion &localDeletion, mLocalDeletions) {
+        uidToRecurrenceIdDeletions.insert(localDeletion.deletedIncidence->uid(), localDeletion.deletedIncidence->recurrenceId());
+        uidToEtagAndUri.insert(localDeletion.deletedIncidence->uid(), qMakePair(localDeletion.remoteEtag, localDeletion.hrefUri));
+    }
+
+    // now send DELETEs as required, and PUTs as required.
+    Q_FOREACH (const QString &uid, uidToRecurrenceIdDeletions.keys()) {
+        QList<KDateTime> recurrenceIds = uidToRecurrenceIdDeletions.values(uid);
+        if (!recurrenceIds.contains(KDateTime())) {
+            // one or more persistent exceptions are being deleted; must PUT.
+            if (addModUids.contains(uid)) {
+                LOG_DEBUG("Already handled this exception deletion in another exception update");
+                continue;
+            }
+            Put *put = new Put(mNetworkManager, mSettings);
+            mRequests.insert(put);
+            connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
+            KCalCore::Incidence::Ptr recurringSeries = mCalendar->incidence(uid, KDateTime());
+            if (!recurringSeries.isNull()) {
+                put->updateEvent(mRemoteCalendarPath,
+                                 constructLocalChangeIcs(recurringSeries),
+                                 uidToEtagAndUri.value(uid).first,
+                                 uidToEtagAndUri.value(uid).second,
+                                 uid);
+                continue; // finished with this deletion.
+            } else {
+                LOG_WARNING("Unable to load recurring incidence for deleted exception; deleting entire series instead");
+                // fall through to the DELETE code below.
+            }
+        }
+
+        // the whole series is being deleted; can DELETE.
+        QString remoteUri = uidToEtagAndUri.value(uid).second;
+        LOG_DEBUG("deleting whole series:" << remoteUri << "with uid:" << uid);
+        Delete *del = new Delete(mNetworkManager, mSettings);
+        mRequests.insert(del);
+        connect(del, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
+        del->deleteEvent(remoteUri);
+    }
+}
+
+void NotebookSyncAgent::nonReportRequestFinished()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    Request *request = qobject_cast<Request*>(sender());
+    if (!request) {
+        emitFinished(Buteo::SyncResults::INTERNAL_ERROR, QStringLiteral("Invalid request object"));
+        return;
+    }
+    mRequests.remove(request);
+
+    if (request->errorCode() != Buteo::SyncResults::NO_ERROR) {
+        LOG_CRITICAL("Aborting sync," << request->command() << "failed" << request->errorString() << "for notebook" << mCalendarPath << "of account:" << mNotebookAccountId);
+        emitFinished(request->errorCode(), request->errorString());
+    } else {
+        Put *putRequest = qobject_cast<Put*>(request);
+        if (putRequest) {
+            QHash<QString, QString> updatedETags = putRequest->updatedETags();
+            Q_FOREACH (const QString &uri, updatedETags.keys()) {
+                mUpdatedETags[uri] = updatedETags[uri];
+            }
+        }
+        if (mRequests.isEmpty()) {
+            finalizeSendingLocalChanges();
+        }
+    }
+    request->deleteLater();
+}
+
+void NotebookSyncAgent::finalizeSendingLocalChanges()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    // After upsyncing changes (additions + modifications) we need to update local incidences.
+    // For modifications, we need to get the new (server-side) etag values, and store them into those incidences.
+    // For additions, we need to do that, and ALSO update the local URI value (to remote resource path).
+    // We then set the modification date back to what is was before, so that the ETAG/URI update
+    // doesn't get reported as an event modification during our next sync cycle.
+
+    QStringList hrefsToReload;
+    for (int i = 0; i < mLocalAdditions.count(); i++) {
+        KCalCore::Incidence::Ptr &incidence = mLocalAdditions[i];
+        QString href = mRemoteCalendarPath + incidence->uid() + ".ics"; // that's where we PUT the addition.
+        if (!mUpdatedETags.contains(href)) {
+            LOG_DEBUG("Did not receive ETag for incidence " << incidence->uid() << "- will reload from server");
+            if (!hrefsToReload.contains(href)) {
+                hrefsToReload.append(href);
+            }
+        } else {
+            // Set the URI and the ETAG property to the required values.
+            LOG_DEBUG("Adding URI and ETAG to locally added incidence:" << incidence->uid() << incidence->recurrenceId().toString() << ":" << href << mUpdatedETags[href]);
+            KDateTime modDate = incidence->lastModified();
+            incidence->startUpdates();
+            setIncidenceHrefUri(incidence, href);
+            setIncidenceETag(incidence, mUpdatedETags[href]);
+            incidence->setLastModified(modDate);
+            incidence->endUpdates();
+            Reader::CalendarResource resource;
+            resource.etag = mUpdatedETags[href];
+            resource.href = href;
+            resource.incidences = KCalCore::Incidence::List() << incidence;
+            KCalCore::ICalFormat icalFormat;
+            resource.iCalData = icalFormat.toICalString(IncidenceHandler::incidenceToExport(incidence));
+            mReceivedCalendarResources.append(resource);
+        }
+    }
+
+    for (int i = 0; i < mLocalModifications.count(); i++) {
+        KCalCore::Incidence::Ptr &incidence = mLocalModifications[i];
+        QString href = incidenceHrefUri(incidence);
+        if (!mUpdatedETags.contains(href)) {
+            LOG_DEBUG("Did not receive ETag for incidence " << incidence->uid() << "- will reload from server");
+            if (!hrefsToReload.contains(href)) {
+                hrefsToReload.append(href);
+            }
+        } else {
+            LOG_DEBUG("Updating ETAG in locally modified incidence:" << incidence->uid() << incidence->recurrenceId().toString() << ":" << mUpdatedETags[href]);
+            KDateTime modDate = incidence->lastModified();
+            incidence->startUpdates();
+            setIncidenceETag(incidence, mUpdatedETags[href]);
+            incidence->setLastModified(modDate);
+            incidence->endUpdates();
+            Reader::CalendarResource resource;
+            resource.etag = mUpdatedETags[href];
+            resource.href = href;
+            resource.incidences = KCalCore::Incidence::List() << incidence;
+            KCalCore::ICalFormat icalFormat;
+            resource.iCalData = icalFormat.toICalString(IncidenceHandler::incidenceToExport(incidence));
+            mReceivedCalendarResources.append(resource);
+        }
+    }
+
+    if (!hrefsToReload.isEmpty()) {
+        Report *report = new Report(mNetworkManager, mSettings);
+        mRequests.insert(report);
+        connect(report, SIGNAL(finished()), this, SLOT(additionalReportRequestFinished()));
+        report->multiGetEvents(mRemoteCalendarPath, hrefsToReload);
+        return;
+    } else {
+        emitFinished(Buteo::SyncResults::NO_ERROR, QStringLiteral("Finished requests for %1").arg(mNotebook->account()));
+    }
+}
+
+void NotebookSyncAgent::additionalReportRequestFinished()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    // The server did not originally respond with the update ETAG values after
+    // our initial PUT/UPDATE so we had to do an addition report request.
+    // This response will contain the new ETAG values for any resource we
+    // upsynced (ie, a local modification/addition).
+
+    Report *report = qobject_cast<Report*>(sender());
+    mRequests.remove(report);
+    report->deleteLater();
+
+    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
+        mReceivedCalendarResources.append(report->receivedCalendarResources().values());
+        LOG_DEBUG("Additional report request finished: received:"
+                  << report->receivedCalendarResources().size() << "iCal blobs containing a total of"
+                  << report->receivedCalendarResources().values().count() << "incidences");
+        LOG_DEBUG("Have received" << mReceivedCalendarResources.count() << "incidences in total!");
+        emitFinished(Buteo::SyncResults::NO_ERROR, QStringLiteral("Finished requests for %1").arg(mNotebook->account()));
+        return;
+    }
+    emitFinished(report->errorCode(), report->errorString());
+}
+
+bool NotebookSyncAgent::applyRemoteChanges()
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    if (mSyncMode == SlowSync) {
+        // delete the existing notebook associated with this calendar path, if it exists
+        // TODO: if required.  Currently we don't support per-notebook clean sync.
+
+        // and create a new one
+        mNotebook = mKCal::Notebook::Ptr(new mKCal::Notebook(mNotebookName, QString()));
+        mNotebook->setAccount(mNotebookAccountId);
+        mNotebook->setPluginName(mPluginName);
+        mNotebook->setSyncProfile(mSyncProfile + ":" + mCalendarPath); // ugly hack because mkcal API is deficient.  I wanted to use uid field but it won't save.
+        mNotebook->setColor(mColor);
+        if (!mStorage->addNotebook(mNotebook)) {
+            LOG_DEBUG("Unable to (re)create notebook" << mNotebookName << "during slow sync for account" << mNotebookAccountId << ":" << mCalendarPath);
+            return false;
+        }
+    }
+
+    if (!updateIncidences(mReceivedCalendarResources)) {
+        return false;
+    }
+    if (!deleteIncidences(mRemoteDeletions)) {
+        return false;
+    }
+
+    mNotebook->setSyncDate(mNotebookSyncedDateTime);
+    mStorage->updateNotebook(mNotebook);
+
+    return true;
+}
+
+void NotebookSyncAgent::emitFinished(int minorErrorCode, const QString &message)
+{
+    NOTEBOOK_FUNCTION_CALL_TRACE;
+
+    if (mFinished) {
+        return;
+    }
+    mNotebookSyncedDateTime = KDateTime::currentUtcDateTime();
+    mFinished = true;
+    clearRequests();
+
+    emit finished(minorErrorCode, message);
 }
 
 void NotebookSyncAgent::finalize()
 {
     NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    LOG_DEBUG("Writing" << mNewRemoteIncidenceIds.count() << "insertions,"
-              << mModifiedIncidenceICalData.count() << "modifications,"
-              << mIncidenceIdsToDelete.count() << "deletions,"
-              << mUpdatedETags.count() << "updated etags");
-
-    // remove additions, modifications and deletions from the last sync session
-    // (don't call removeEntries() as that clears etags and calendars also)
-    mDatabase->removeIncidenceChangeEntriesOnly(mNotebook->uid());
-
-    mDatabase->setNeedsCleanSync(mNotebook->uid(), false); // TODO: on error, set to true?
-    if (mNewRemoteIncidenceIds.count()) {
-        mDatabase->insertAdditions(mNotebook->uid(), mNewRemoteIncidenceIds);
-        mNewRemoteIncidenceIds.clear();
-    }
-    if (mModifiedIncidenceICalData.count()) {
-        mDatabase->insertModifications(mNotebook->uid(), mModifiedIncidenceICalData);
-        mModifiedIncidenceICalData.clear();
-    }
-    if (mIncidenceIdsToDelete.count()) {
-        mDatabase->insertDeletions(mNotebook->uid(), mIncidenceIdsToDelete);
-        mIncidenceIdsToDelete.clear();
-    }
-    if (mUpdatedETags.count()) {
-        mDatabase->insertETags(mNotebook->uid(), mUpdatedETags);
-        mUpdatedETags.clear();
-    }
 }
 
 bool NotebookSyncAgent::isFinished() const
@@ -237,14 +715,269 @@ bool NotebookSyncAgent::isFinished() const
     return mFinished;
 }
 
-void NotebookSyncAgent::fetchRemoteChanges(const QDateTime &fromDateTime, const QDateTime &toDateTime)
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
+// ------------------------------ Utility / implementation functions.
 
-    Report *report = new Report(mNAManager, mSettings);
-    mRequests.insert(report);
-    connect(report, SIGNAL(finished()), this, SLOT(processETags()));
-    report->getAllETags(mServerPath, fromDateTime, toDateTime);
+// called in the QuickSync codepath after fetching etags for remote resources.
+// from the etags, we can determine the local and remote sync delta.
+bool NotebookSyncAgent::calculateDelta(
+        // in parameters:
+        const KDateTime &fromDate,                     //  fromDate:    date to load local changes since
+        const QHash<QString, QString> &remoteUriEtags, //  remoteEtags: map of uri to etag which exist on the remote server.
+        // out parameters:
+        KCalCore::Incidence::List *localAdditions,
+        KCalCore::Incidence::List *localModifications,
+        QList<LocalDeletion> *localDeletions,
+        QList<QString> *remoteAdditions,
+        QList<QString> *remoteModifications,
+        KCalCore::Incidence::List *remoteDeletions)
+{
+    // Note that the mKCal API doesn't provide a way to get all deleted/modified incidences
+    // for a notebook, as it implements the SQL query using an inequality on both modifiedAfter
+    // and createdBefore; so instead we have to build a datetime which "should" satisfy
+    // the inequality for all possible local modifications detectable since the last sync.
+    KDateTime syncDateTime = mNotebook->syncDate().addSecs(1); // deleted after, created before...
+
+    // load all local incidences
+    KCalCore::Incidence::List localIncidences;
+    if (!mStorage->allIncidences(&localIncidences, mNotebook->uid())) {
+        emitFinished(Buteo::SyncResults::DATABASE_FAILURE, QString("Unable to load storage incidences for notebook: %1").arg(mNotebook->uid()));
+        return false;
+    }
+
+    // separate them into buckets.
+    // note that each remote URI can be associated with multiple local incidences (due recurrenceId incidences)
+    // Here we can determine local additions and remote deletions.
+    QSet<QString> seenRemoteUris;
+    QHash<QString, QString> previouslySyncedEtags; // remote uri to the etag we saw last time.
+    Q_FOREACH (KCalCore::Incidence::Ptr incidence, localIncidences) {
+        bool uriWasEmpty = false;
+        QString remoteUri = incidenceHrefUri(incidence, mRemoteCalendarPath, &uriWasEmpty);
+        if (uriWasEmpty) {
+            // must be either a new local addition or a previously-upsynced local addition
+            // if we failed to update its uri after the successful upsync.
+            if (remoteUriEtags.contains(remoteUri)) { // we saw this on remote side...
+                // previously partially upsynced, needs uri update.
+                LOG_DEBUG("have previously partially upsynced local addition, needs uri update:" << remoteUri);
+                seenRemoteUris.insert(remoteUri);
+            } else { // it doesn't exist on remote side...
+                // new local addition.
+                LOG_DEBUG("have new local addition:" << incidence->uid() << incidence->recurrenceId().toString());
+                localAdditions->append(incidence);
+                // Note: if it was partially upsynced and then connection failed
+                // and then removed remotely, then on next sync (ie, this one)
+                // it will appear like a "new" local addition.  TODO: FIXME? How?
+            }
+        } else {
+            // this is a previously-synced incidence with a remote uri.
+            if (!remoteUriEtags.contains(remoteUri)) {
+                LOG_DEBUG("have remote deletion of previously synced incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                remoteDeletions->append(incidence);
+            } else {
+                // this is a possibly modified or possibly unchanged, previously synced incidence.
+                LOG_DEBUG("have possibly modified or possibly unchanged previously synced local incidence:" << remoteUri);
+                seenRemoteUris.insert(remoteUri);
+                previouslySyncedEtags.insert(remoteUri, incidenceETag(incidence));
+            }
+        }
+    }
+
+    // now determine local deletions.  Note that we combine deletions reported since
+    // the from date and since the last sync date, due to mKCal API semantics.
+    KCalCore::Incidence::List deleted, deletedSyncDate;
+    uniteIncidenceLists(deletedSyncDate, &deleted);
+    if (!mStorage->deletedIncidences(&deleted, fromDate, mNotebook->uid()) ||
+        !mStorage->deletedIncidences(&deletedSyncDate, syncDateTime, mNotebook->uid())) {
+        LOG_CRITICAL("mKCal::ExtendedStorage::deletedIncidences() failed");
+        return false;
+    }
+    Q_FOREACH (KCalCore::Incidence::Ptr incidence, deleted) {
+        bool uriWasEmpty = false;
+        QString remoteUri = incidenceHrefUri(incidence, mRemoteCalendarPath, &uriWasEmpty);
+        if (remoteUriEtags.contains(remoteUri)) {
+            if (uriWasEmpty) {
+                // we originally upsynced this pure-local addition, but then connectivity was
+                // lost before we updated the uid of it locally to include the remote uri.
+                // subsequently, the user deleted the incidence.
+                // Hence, it exists remotely, and has been deleted locally.
+                LOG_DEBUG("have local deletion for partially synced incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+            } else {
+                // the incidence was previously synced successfully.  it has now been deleted locally.
+                LOG_DEBUG("have local deletion for previously synced incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+            }
+            LocalDeletion localDeletion(incidence, remoteUriEtags.value(remoteUri), remoteUri);
+            localDeletions->append(localDeletion);
+            seenRemoteUris.insert(remoteUri);
+        } else {
+            // it was either already deleted remotely, or was never upsynced from the local prior to deletion.
+            LOG_DEBUG("ignoring local deletion of non-existent remote incidence:" << incidence->uid() << incidence->recurrenceId().toString() << "at" << remoteUri);
+        }
+    }
+
+    // now determine local modifications.  Note that we combine modifications reported since
+    // the from date and since the last sync date, due to mKCal API semantics.
+    KCalCore::Incidence::List modified, modifiedSyncDate;
+    if (!mStorage->modifiedIncidences(&modified, fromDate, mNotebook->uid()) ||
+        !mStorage->modifiedIncidences(&modifiedSyncDate, syncDateTime, mNotebook->uid())) {
+        LOG_CRITICAL("mKCal::ExtendedStorage::modifiedIncidences() failed");
+        return false;
+    }
+    uniteIncidenceLists(modifiedSyncDate, &modified);
+    Q_FOREACH (KCalCore::Incidence::Ptr incidence, modified) {
+        // if it also appears in localDeletions, ignore it - it was deleted locally.
+        // if it also appears in localAdditions, ignore it - we are already uploading it.
+        // if it doesn't appear in remoteEtags, ignore it - it was deleted remotely.
+        // if its etag has changed remotely, ignore it - it was modified remotely.
+        bool uriWasEmpty = false;
+        QString remoteUri = incidenceHrefUri(incidence, mRemoteCalendarPath, &uriWasEmpty);
+        if (uriWasEmpty) {
+            // incidence either hasn't been synced before, or was partially synced.
+            if (remoteUriEtags.contains(remoteUri)) { // yep, we previously upsynced it but then connectivity died.
+                // partially synced previously, connectivity died before we could update the uri field with remote url.
+                LOG_DEBUG("have local modification to partially synced incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                // note: we cannot check the etag to determine if it changed, since we may not have received the updated etag after the partial sync.
+                // we treat this as a "definite" local modification due to the partially-synced status.
+                localModifications->append(incidence);
+                seenRemoteUris.insert(remoteUri);
+            } else if (localAdditions->contains(incidence)) {
+                LOG_DEBUG("ignoring local modification to locally added incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                continue;
+            } else {
+                LOG_DEBUG("ignoring local modification to remotely removed partially-synced incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                continue;
+            }
+        } else {
+            // we have a modification to a previously-synced incidence.
+            QString localEtag = incidenceETag(incidence);
+            if (!remoteUriEtags.contains(remoteUri)) {
+                LOG_DEBUG("ignoring local modification to remotely deleted incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                bool foundRemoteDeletion = false;
+                for (int i = 0; i < remoteDeletions->size(); ++i) {
+                    if (remoteDeletions->at(i)->uid() == incidence->uid() && remoteDeletions->at(i)->recurrenceId() == incidence->recurrenceId()) {
+                        foundRemoteDeletion = true;
+                        break;
+                    }
+                }
+                if (!foundRemoteDeletion) {
+                    // this should never happen, and is always an error.
+                    LOG_WARNING("But unable to find corresponding remote deletion!  Aborting sync due to unrecoverable error!");
+                    return false;
+                }
+            } else {
+                // determine if the remote etag is still the same.
+                // if it is not, then the incidence was modified server-side.
+                if (localEtag != remoteUriEtags.value(remoteUri)) {
+                    // if the etags are different, then the event was also modified remotely.
+                    // we only support PreferRemote conflict resolution, so we discard the local modification.
+                    LOG_DEBUG("ignoring local modification to remotely modified incidence:" << incidence->uid() << incidence->recurrenceId().toString());
+                    remoteModifications->append(remoteUri);
+                } else {
+                    // this is either a real local modification, or a modification being reported due to URI/ETAG update after previous sync.
+                    // because it may be being reported due solely to URI/ETAG update, we treat it as a "possible" local modification.
+                    LOG_DEBUG("have possible local modification:" << incidence->uid() << incidence->recurrenceId().toString());
+                    localModifications->append(incidence); // NOTE: we later reload this event from server to detect "true" delta.
+                    mPossibleLocalModificationIncidenceIds.insert(remoteUri, incidence->recurrenceId());
+                }
+                seenRemoteUris.insert(remoteUri);
+            }
+        }
+    }
+
+    // now determine remote additions and modifications.
+    Q_FOREACH (const QString &remoteUri, remoteUriEtags.keys()) {
+        if (!seenRemoteUris.contains(remoteUri)) {
+            // this is probably a pure server-side addition, but there is one other possibility:
+            // if it was newly added to the server before the previous sync cycle, then it will
+            // have been added locally (due to remote addition) during the last sync cycle.
+            // If the event was subsequently deleted locally prior to this sync cycle, then
+            // mKCal will NOT report it as a deletion (or an addition) because it assumes that
+            // it was a pure local addition + deletion.
+            // The solution?  We need to manually search every deleted incidence for uri value.
+            // Unfortunately, the mKCal API doesn't allow us to get all deleted incidences,
+            // but we can get all incidences deleted since the last sync date.
+            // That should suffice, and we've already injected those deletions into the deletions
+            // list, so if we hit this branch, then it must be a new remote addition.
+            LOG_DEBUG("have new remote addition:" << remoteUri);
+            remoteAdditions->append(remoteUri);
+        } else if (!previouslySyncedEtags.contains(remoteUri)) {
+            // this is a server-side modification which is obsoleted by a local deletion
+            LOG_DEBUG("ignoring remote modification to locally deleted incidence at:" << remoteUri);
+        } else if (previouslySyncedEtags.value(remoteUri) != remoteUriEtags.value(remoteUri)) {
+            // etag changed; this is a server-side modification.
+            LOG_DEBUG("have remote modification to previously synced incidence at:" << remoteUri);
+            LOG_DEBUG("previously seen ETag was:" << previouslySyncedEtags.value(remoteUri) << "-> new ETag is:" << remoteUriEtags.value(remoteUri));
+            remoteModifications->append(remoteUri);
+        } else {
+            // this incidence is unchanged since last sync.
+            LOG_DEBUG("unchanged server-side since last sync:" << remoteUri);
+        }
+    }
+
+    LOG_DEBUG("Calculated local  A/M/R:" << localAdditions->size() << "/" << localModifications->size() << "/" << localDeletions->size());
+    LOG_DEBUG("Calculated remote A/M/R:" << remoteAdditions->size() << "/" << remoteModifications->size() << "/" << remoteDeletions->size());
+
+    return true;
+}
+
+// Called in the QuickSync codepath after some local modifications were reported by mKCal.
+// We fetched the remote version of the resource so that we can detect whether the local change
+// is "real" or whether it was just reporting the local modification of the ETAG or URI field.
+void NotebookSyncAgent::removePossibleLocalModificationIfIdentical(
+        const QString &remoteUri,
+        const QList<KDateTime> &recurrenceIds,
+        const QList<Reader::CalendarResource> &remoteResources,
+        KCalCore::Incidence::List *localModifications)
+{
+    // the remoteResources list contains all of the ical resources fetched from the remote URI.
+    bool foundMatch = false;
+    Q_FOREACH (const KDateTime &rid, recurrenceIds) {
+        // find the possible local modification associated with this recurrenceId.
+        int removeIdx = -1;
+        for (int i = 0; i < localModifications->size(); ++i) {
+            // Note: we compare the remote resources with the "export" version of the local modifications
+            // otherwise spurious differences might be detected.
+            const KCalCore::Incidence::Ptr &pLMod = IncidenceHandler::incidenceToExport(localModifications->at(i));
+            if (pLMod->recurrenceId() == rid) {
+                // found the local incidence.  now find the copy received from the server and detect changes.
+                Q_FOREACH (const Reader::CalendarResource &resource, remoteResources) {
+                    if (resource.href != remoteUri) {
+                        LOG_WARNING("error while removing spurious possible local modifications: resource uri mismatch:" << resource.href << "->" << remoteUri);
+                    } else {
+                        Q_FOREACH (const KCalCore::Incidence::Ptr &remoteIncidence, resource.incidences) {
+                            if (remoteIncidence->recurrenceId() == rid) {
+                                // found the remote incidence.  compare it to the local.
+                                foundMatch = true;
+                                if (IncidenceHandler::copiedPropertiesAreEqual(pLMod, remoteIncidence)) {
+                                    removeIdx = i;  // this is a spurious local modification which needs to be removed.
+                                } else {
+                                    removeIdx = -1; // this is a real local modification. no-op, but for completeness.
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    if (foundMatch) {
+                        break;
+                    }
+                }
+            }
+            if (foundMatch) {
+                break;
+            }
+        }
+
+        // remove the possible local modification if it proved to be spurious
+        if (foundMatch) {
+            if (removeIdx >= 0) {
+                LOG_DEBUG("discarding spurious local modification to:" << remoteUri << rid.toString());
+                localModifications->remove(removeIdx);
+            } else {
+                LOG_DEBUG("local modification to:" << remoteUri << rid.toString() << "is real.");
+            }
+        } else {
+            // this is always an internal logic error.  We explicitly requested it.
+            LOG_WARNING("error: couldn't find remote incidence for possible local modification! FIXME!");
+        }
+    }
 }
 
 // A given incidence has been added or modified locally.
@@ -306,698 +1039,22 @@ QString NotebookSyncAgent::constructLocalChangeIcs(KCalCore::Incidence::Ptr upda
     return icalFormat.toString(memoryCalendar, QString(), false);
 }
 
-void NotebookSyncAgent::sendLocalChanges()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    QSet<KCalId> deleted;
-    mLocallyInsertedIncidences.clear();
-    mLocallyModifiedIncidences.clear();
-    if (!loadLocalChanges(mChangesSinceDate, &mLocallyInsertedIncidences, &mLocallyModifiedIncidences, &deleted)) {
-        emitFinished(Buteo::SyncResults::INTERNAL_ERROR, "Unable to load changes for calendar: " + mServerPath);
-        return;
-    }
-    if (mLocallyInsertedIncidences.isEmpty() && mLocallyModifiedIncidences.isEmpty() && deleted.isEmpty()) {
-        LOG_DEBUG("No changes to send!");
-        emitFinished(Buteo::SyncResults::NO_ERROR, "Done, no local changes for " + mServerPath);
-        return;
-    }
-    LOG_DEBUG("Total local changes for" << mServerPath << ":"
-              << "inserted = " << mLocallyInsertedIncidences.count()
-              << ", modified = " << mLocallyModifiedIncidences.count()
-              << ", deleted = " << deleted.count());
-
-    QSet<QString> addModUids;
-    for (int i=0; i<mLocallyInsertedIncidences.count(); i++) {
-        if (addModUids.contains(mLocallyInsertedIncidences[i]->uid())) {
-            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
-        } else {
-            addModUids.insert(mLocallyInsertedIncidences[i]->uid());
-        }
-        Put *put = new Put(mNAManager, mSettings);
-        mRequests.insert(put);
-        connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
-        put->createEvent(mServerPath,
-                         constructLocalChangeIcs(mLocallyInsertedIncidences[i]),
-                         KCalId(mLocallyInsertedIncidences[i]));
-    }
-    for (int i=0; i<mLocallyModifiedIncidences.count(); i++) {
-        if (addModUids.contains(mLocallyModifiedIncidences[i]->uid())) {
-            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
-        }
-        // first, handle updates of exceptions by uploading the entire modified series.
-        if (mLocallyModifiedIncidences[i]->hasRecurrenceId()) {
-            Put *put = new Put(mNAManager, mSettings);
-            mRequests.insert(put);
-            connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
-            addModUids.insert(mLocallyModifiedIncidences[i]->uid());
-            put->updateEvent(mServerPath,
-                             constructLocalChangeIcs(mLocallyModifiedIncidences[i]),
-                             mLocalETags.value(mLocallyModifiedIncidences[i]->customProperty("buteo", "uri")),
-                             mLocallyModifiedIncidences[i]->customProperty("buteo", "uri"),
-                             KCalId(mLocallyModifiedIncidences[i]));
-        }
-    }
-    for (int i=0; i<mLocallyModifiedIncidences.count(); i++) {
-        if (addModUids.contains(mLocallyModifiedIncidences[i]->uid())) {
-            continue; // already handled this one, as a result of a previous update of another occurrence in the series.
-        }
-        // now handle updates of base incidences (which haven't otherwise already been upsynced), via direct update.
-        KCalCore::ICalFormat icalFormat;
-        Put *put = new Put(mNAManager, mSettings);
-        mRequests.insert(put);
-        connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
-        put->updateEvent(mServerPath,
-                         icalFormat.toICalString(IncidenceHandler::incidenceToExport(mLocallyModifiedIncidences[i])),
-                         mLocalETags.value(mLocallyModifiedIncidences[i]->customProperty("buteo", "uri")),
-                         mLocallyModifiedIncidences[i]->customProperty("buteo", "uri"),
-                         KCalId(mLocallyModifiedIncidences[i]));
-    }
-
-    // For deletions, if a persistent exception is deleted we may need to do a PUT
-    // containing all of the still-existing events in the series.
-    // (Alternative is to push a STATUS:CANCELLED event?)
-    // Hence, we first need to find out if any deletion is a lone-persistent-exception deletion.
-    QMultiHash<QString, KDateTime> uidToRecurrenceIdDeletions;
-    Q_FOREACH (const KCalId &kcalid, deleted) {
-        uidToRecurrenceIdDeletions.insert(kcalid.uid, kcalid.recurrenceId);
-    }
-
-    // now send DELETEs as required, and PUTs as required.
-    Q_FOREACH (const QString &uid, uidToRecurrenceIdDeletions.keys()) {
-        QList<KDateTime> recurrenceIds = uidToRecurrenceIdDeletions.values(uid);
-        if (!recurrenceIds.contains(KDateTime())) {
-            // one or more persistent exceptions are being deleted; must PUT.
-            if (addModUids.contains(uid)) {
-                LOG_DEBUG("Already handled this exception deletion in another exception update");
-                continue;
-            }
-            Put *put = new Put(mNAManager, mSettings);
-            mRequests.insert(put);
-            connect(put, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
-            KCalCore::Incidence::Ptr recurringSeries = mCalendar->incidence(uid, KDateTime());
-            if (!recurringSeries.isNull()) {
-                put->updateEvent(mServerPath,
-                                 constructLocalChangeIcs(recurringSeries),
-                                 mLocalETags[recurringSeries->customProperty("buteo", "uri")],
-                                 recurringSeries->customProperty("buteo", "uri"),
-                                 KCalId(recurringSeries));
-                continue; // finished with this deletion.
-            } else {
-                LOG_WARNING("Unable to load recurring incidence for deleted exception; deleting entire series instead");
-                // fall through to the DELETE code below.
-            }
-        }
-
-        // the whole series is being deleted; can DELETE.
-        Delete *del = new Delete(mNAManager, mSettings);
-        mRequests.insert(del);
-        connect(del, SIGNAL(finished()), this, SLOT(nonReportRequestFinished()));
-
-        // We have to determine the correct href of the deleted incidence. Unfortunately,
-        // the storage backend deletes all custom properties of deleted incidences, so
-        // we cannot use customProperty("buteo", "uri").
-        // Fortunately, the deleted incidence can be found in mReceivedCalendarResources.
-        QString href;
-        Q_FOREACH(const Reader::CalendarResource &resource, mReceivedCalendarResources) {
-            if (!resource.incidences.isEmpty() && (uid == resource.incidences.first()->uid())) {
-                href = resource.href;
-            }
-        }
-        if (href.isNull()) {
-            emitFinished(Buteo::SyncResults::INTERNAL_ERROR,
-                         "Unable to determine href for locally deleted incidence:" + uid);
-        }
-        del->deleteEvent(href);
-    }
-}
-
-bool NotebookSyncAgent::loadLocalChanges(const QDateTime &fromDate,
-                                         KCalCore::Incidence::List *inserted,
-                                         KCalCore::Incidence::List *modified,
-                                         QSet<KCalId> *deleted)
-{
-    FUNCTION_CALL_TRACE;
-
-    if (!mStorage) {
-        LOG_CRITICAL("mStorage not set");
-        return false;
-    }
-    QString notebookUid = mNotebook->uid();
-    KDateTime kFromDate(fromDate);
-    if (!mStorage->insertedIncidences(inserted, kFromDate, notebookUid)) {
-        LOG_CRITICAL("mKCal::ExtendedStorage::insertedIncidences() failed");
-        return false;
-    }
-    if (!mStorage->modifiedIncidences(modified, kFromDate, notebookUid)) {
-        LOG_CRITICAL("mKCal::ExtendedStorage::modifiedIncidences() failed");
-        return false;
-    }
-
-    KCalCore::Incidence::List deletedIncidences;
-    if (!mStorage->deletedIncidences(&deletedIncidences, kFromDate, notebookUid)) {
-        LOG_CRITICAL("mKCal::ExtendedStorage::deletedIncidences() failed");
-        return false;
-    }
-    Q_FOREACH(const KCalCore::Incidence::Ptr &incidence, deletedIncidences) {
-        deleted->insert(KCalId(incidence));
-    }
-
-    LOG_DEBUG("Initially found changes for" << mServerPath << "since" << fromDate << ":"
-              << "inserted = " << inserted->count()
-              << "modified = " << modified->count()
-              << "deleted = " << deleted->count());
-
-    // Any server changes synced to the local db during the last sync will be picked up as
-    // "local changes", so we must discard these changes so that they are not sent back to
-    // the server on this next sync.
-    if (!discardRemoteChanges(inserted, modified, deleted)) {
-        return false;
-    }
-    // If an event has changed to/from the caldav notebook and back since the last sync,
-    // it will be present in both the inserted and deleted lists. In this case, nothing
-    // has actually changed, so remove it from both lists.
-    int removed = removeCommonIncidences(inserted, deleted);
-    if (removed > 0) {
-        LOG_DEBUG("Removed" << removed << "UIDs found in both inserted and removed lists");
-    }
-    return true;
-}
-
-// discard local changes which are obsoleted by remote changes, or caused by previous remote changes.
-bool NotebookSyncAgent::discardRemoteChanges(KCalCore::Incidence::List *localInserted,
-                                             KCalCore::Incidence::List *localModified,
-                                             QSet<KCalId> *localDeleted)
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    // Go through the local inserted, modified and deletions list and:
-    // - Discard from them respectively the additions, modifications and deletions that were
-    //   created as a result of the last remote sync.
-    // - Discard any incidences that have already been deleted on the server. (These will be
-    //   deleted locally when the current sync finishes.)
-    // - Discard any local modifications that were modified on the server, as the server
-    //   modifications take precedence.
-
-    if (!mNotebook) {
-        LOG_CRITICAL("no notebook");
-        return false;
-    }
-    bool ok = false;
-    QSet<KCalId> remoteDeletedIncidences(mIncidenceIdsToDelete);
-
-    QSet<KCalId> additions = mDatabase->additions(mNotebook->uid(), &ok);
-    if (!ok) {
-        LOG_CRITICAL("Unable to look up last sync additions for notebook:" << mNotebook->uid());
-        return false;
-    }
-    Q_FOREACH (const KCalId &kcalid, additions) {
-        LOG_TRACE("Tracking previous addition:" << kcalid.uid << kcalid.recurrenceId.toString());
-    }
-
-    QHash<KCalId,QString> modifications = mDatabase->modifications(mNotebook->uid(), &ok);
-    if (!ok) {
-        LOG_CRITICAL("Unable to look up last sync modifications for notebook:" << mNotebook->uid());
-        return false;
-    }
-    Q_FOREACH (const KCalId &kcalid, modifications.keys()) {
-        LOG_TRACE("Tracking previous modification:" << kcalid.uid << kcalid.recurrenceId.toString() << "==>" << modifications.value(kcalid));
-    }
-
-    for (KCalCore::Incidence::List::iterator it = localInserted->begin(); it != localInserted->end();) {
-        const KCalCore::Incidence::Ptr &incidence = *it;
-        const KCalId &kcalid = KCalId(incidence);
-        if (remoteDeletedIncidences.contains(kcalid)) {
-            LOG_DEBUG("Discarding addition deleted on server:" << kcalid.toString());
-            it = localInserted->erase(it);
-        } else if (additions.contains(kcalid)) {
-            if (incidence->lastModified().isValid() && incidence->lastModified() > incidence->created()) {
-                // This incidence has been modified since it was added from the server in the last sync,
-                // so it's a modification rather than an addition.
-                LOG_DEBUG("Moving to modified:" << kcalid.toString());
-                KCalCore::Incidence::Ptr savedIncidence = mCalendar->incidence(kcalid.uid, kcalid.recurrenceId);
-                if (savedIncidence) {
-                    localModified->append(savedIncidence);
-                    it = localInserted->erase(it);
-                } else {
-                    ++it;
-                }
-            } else {
-                LOG_DEBUG("Discarding addition from previous sync:" << kcalid.toString());
-                it = localInserted->erase(it);
-            }
-        } else if (modifications.contains(kcalid)) {
-            // Sometimes recurring event exception modifications are treated as additions of
-            // both the exception _and_ the recurring event, by loadIncidences().  I don't know why.
-            // This check ensures that we also check previous modifications to see if the event
-            // is tracked there.
-            LOG_DEBUG("Discarding tracked recurring event modification (reported as addition) from previous sync:" << kcalid.toString());
-            it = localInserted->erase(it);
-        } else {
-            LOG_DEBUG("Entirely new addition:" << incidence->uid() << incidence->recurrenceId().toString());
-            ++it;
-        }
-    }
-
-    for (KCalCore::Incidence::List::iterator it = localModified->begin(); it != localModified->end();) {
-        KCalCore::Incidence::Ptr sourceIncidence = *it;
-        const KCalId &kcalid = KCalId(sourceIncidence);
-        if (remoteDeletedIncidences.contains(kcalid) || mRemoteModifiedIds.contains(kcalid)) {
-            LOG_DEBUG("Discarding modification,"
-                      << (remoteDeletedIncidences.contains(kcalid) ? "was already deleted on server" : "")
-                      << (mRemoteModifiedIds.contains(kcalid) ? "was already modified on server": ""));
-            it = localModified->erase(it);
-            continue;
-        } else if (modifications.contains(kcalid)) {
-            KCalCore::ICalFormat iCalFormat;
-            KCalCore::Incidence::Ptr receivedIncidence = iCalFormat.fromString(modifications[kcalid]);
-            if (receivedIncidence.isNull()) {
-                LOG_WARNING("Not sending modification, cannot parse the received incidence:" << modifications[kcalid]);
-                it = localModified->erase(it);
-                continue;
-            }
-            // If incidences are the same, then we assume the local incidence was not changed after
-            // the remote incidence was received, and thus there are no modifications to report.
-            IncidenceHandler::prepareImportedIncidence(receivedIncidence);  // ensure fields are updated as per imported incidences
-            if (IncidenceHandler::copiedPropertiesAreEqual(sourceIncidence, receivedIncidence)) {
-                LOG_DEBUG("Discarding modification" << kcalid.toString());
-                it = localModified->erase(it);
-                continue;
-            }
-        }
-
-        // The default storage implementation applies the organizer as an attendee by default. Don't do this
-        // as it turns the incidence into a scheduled event requiring acceptance/rejection/etc.
-        const KCalCore::Person::Ptr organizer = sourceIncidence->organizer();
-        if (organizer) {
-            Q_FOREACH (const KCalCore::Attendee::Ptr &attendee, sourceIncidence->attendees()) {
-                if (attendee->email() == organizer->email() && attendee->fullName() == organizer->fullName()) {
-                    LOG_DEBUG("Discarding organizer as attendee" << attendee->fullName());
-                    sourceIncidence->deleteAttendee(attendee);
-                    break;
-                }
-            }
-        }
-        ++it;
-    }
-
-
-    // Incidences which have been received during the last sync and then were deleted locally
-    // will not show up in localDeleted as their creation time is after the start time of
-    // the last sync. Therefore, go through the list of additions and add all of them which
-    // are missing in the storage to the localDeleted list.
-    Q_FOREACH(const KCalId& kcalid, additions) {
-        if (!mStorageIds.contains(kcalid) && !localDeleted->contains(kcalid)) {
-            LOG_DEBUG("Adding previous addition " << kcalid.toString()
-                      << " to local deletions as it has vanished from local storage");
-            localDeleted->insert(kcalid);
-        }
-    }
-
-    QSet<KCalId> deletions = mDatabase->deletions(mNotebook->uid(), &ok);
-    if (!ok) {
-        LOG_CRITICAL("Unable to look up last sync deletions for notebook:" << mNotebook->uid());
-        return false;
-    }
-    for (QSet<KCalId>::iterator it = localDeleted->begin(); it != localDeleted->end();) {
-        const KCalId &kcalid = *it;
-        if (deletions.contains(kcalid)) {
-            // Ignore locally deleted incidences which have been deleted during the last sync.
-            LOG_DEBUG("Discarding deletion from last sync:" << kcalid.toString());
-            it = localDeleted->erase(it);
-        } else if (!mRemoteUids.contains(kcalid.uid)) {
-            // All locally deleted incidence which are still on the server, have been received
-            // by fetchRemoteChanges. Conversely, all locally deleted incidences which are not
-            // under the seen uids should be ignored as they have already been
-            // deleted on the server.
-            LOG_DEBUG("Discarding deletion, was already deleted on server:" << kcalid.toString());
-            it = localDeleted->erase(it);
-        } else {
-            // Add the uid to mLocalDeletedUids so that we do not insert the incidence as
-            // new incidence later on.
-            mLocalDeletedIds.insert(kcalid);
-            ++it;
-        }
-    }
-
-    return true;
-}
-
-int NotebookSyncAgent::removeCommonIncidences(KCalCore::Incidence::List *firstList, QSet<KCalId> *secondList)
-{
-    QSet<KCalId> firstListUids;
-    for (int i=0; i<firstList->count(); i++) {
-        firstListUids.insert(KCalId(firstList->at(i)));
-    }
-    QSet<KCalId> commonUids;
-    for (QSet<KCalId>::iterator it = secondList->begin(); it != secondList->end();) {
-        if (firstListUids.contains(*it)) {
-            commonUids.insert(*it);
-            it = secondList->erase(it);
-        } else {
-            ++it;
-        }
-    }
-    int removed = commonUids.count();
-    if (removed > 0) {
-        for (KCalCore::Incidence::List::iterator it = firstList->begin(); it != firstList->end();) {
-            const KCalCore::Incidence::Ptr &incidence = *it;
-            if (commonUids.contains(KCalId(incidence))) {
-                commonUids.remove(KCalId(incidence));
-                it = firstList->erase(it);
-            } else {
-                ++it;
-            }
-        }
-    }
-    return removed;
-}
-
-void NotebookSyncAgent::processETags()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    Report *report = qobject_cast<Report*>(sender());
-    mRequests.remove(report);
-    report->deleteLater();
-
-    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
-        LOG_DEBUG("Process tags for server path" << mServerPath);
-        QMultiHash<QString, Reader::CalendarResource> map = report->receivedCalendarResources();
-        QStringList eventIdList;
-        if (mStorageIncidenceList.isEmpty()) {
-            LOG_DEBUG("No local incidences stored, all received resources must be server-side additions");
-        } else {
-            QSet<QString> seenUris;
-            Q_FOREACH (KCalCore::Incidence::Ptr incidence, mStorageIncidenceList) {
-                QString uri = incidence->customProperty("buteo", "uri");
-                if (seenUris.contains(uri)) {
-                    LOG_TRACE("Skipping incidence:" << incidence->uid() << incidence->recurrenceId().toString() << "- already checked it's ETag");
-                    continue;
-                }
-                if (uri.isEmpty()) {
-                    //Newly added to Local DB -- Skip this incidence
-                    LOG_TRACE("Skipping newly-added incidence with no uri:" << incidence->uid() << incidence->recurrenceId().toString());
-                    continue;
-                }
-                if (!map.contains(uri)) {
-                    // we have an incidence that's not on the remote server, so delete it
-                    LOG_DEBUG("Need to delete local-but-not-remote:" << uri);
-                    switch (incidence->type()) {
-                    case KCalCore::IncidenceBase::TypeEvent:
-                    case KCalCore::IncidenceBase::TypeTodo:
-                    case KCalCore::IncidenceBase::TypeJournal:
-                        mIncidenceIdsToDelete.insert(KCalId(incidence));
-                        break;
-                    case KCalCore::IncidenceBase::TypeFreeBusy:
-                    case KCalCore::IncidenceBase::TypeUnknown:
-                        break;
-                    }
-                    continue;
-                } else {
-                    QList<Reader::CalendarResource> resources = map.values(uri);
-                    bool foundNonMatch = false;
-                    QString seenEtag;
-                    for (int i = 0; i < resources.size(); ++i) {
-                        if (mLocalETags.value(resources[i].href) != resources[i].etag) {
-                            // need to update this resource as it has changed server-side.
-                            LOG_DEBUG("Found non-matching ETag:" << mLocalETags.value(resources[i].href) << "for:" << uri << "with ETag:" << resources[i].etag);
-                            // ensure we only fetch once (eg, if we have recurring + occurrence with same href to fetch).
-                            if (!eventIdList.contains(resources[i].href)) {
-                                eventIdList.append(resources[i].href);
-                            }
-                            foundNonMatch = true;
-                            break;
-                        } else {
-                            seenEtag = resources[i].etag;
-                        }
-                    }
-                    if (!foundNonMatch) {
-                        // we can remove this one, this is a known etag.
-                        LOG_DEBUG("All ETags match for uri:" << uri << ":" << seenEtag);
-                        map.remove(uri);
-                        seenUris.insert(uri);
-
-                        // prepopulate the mRemoteUids list with this series' uid
-                        // as it also exists on the server.
-                        mRemoteUids.insert(incidence->uid());
-                    }
-                }
-            }
-        }
-
-        // any items remaining in the map are new events which need to be retrieved.
-        // ensure that we only fetch each given URI once.
-        LOG_DEBUG("Fetching new incidences:" << map.keys());
-        Q_FOREACH (const QString &eventId, map.keys()) {
-            if (!eventIdList.contains(eventId)) {
-                eventIdList.append(eventId);
-            }
-        }
-
-        // fetch updated and new items full data.
-        if (!eventIdList.isEmpty()) {
-            // some incidences have changed on the server, so fetch the new details
-            Report *report = new Report(mNAManager, mSettings);
-            mRequests.insert(report);
-            connect(report, SIGNAL(finished()), this, SLOT(reportRequestFinished()));
-            report->multiGetEvents(mServerPath, eventIdList);
-            return;
-        } else {
-            sendLocalChanges();
-            return;
-        }
-    } else if (report->networkError() == QNetworkReply::AuthenticationRequiredError && !mRetriedReport) {
-        // Yahoo sometimes fails the initial request with an authentication error. Let's try once more
-        LOG_WARNING("Retrying REPORT after request failed with QNetworkReply::AuthenticationRequiredError");
-        mRetriedReport = true;
-        sendReportRequest();
-        return;
-    }
-
-    // no remote changes to downsync, and no local changes to upsync - we're finished.
-    emitFinished(report->errorCode(), report->errorString());
-}
-
-
-void NotebookSyncAgent::reportRequestFinished()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    Report *report = qobject_cast<Report*>(sender());
-    mRequests.remove(report);
-    report->deleteLater();
-
-    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
-        mReceivedCalendarResources = report->receivedCalendarResources().values();
-        Q_FOREACH (const Reader::CalendarResource & resource, mReceivedCalendarResources) {
-            Q_FOREACH (KCalCore::Incidence::Ptr incidence, resource.incidences) {
-                mRemoteUids.insert(incidence->uid());
-                mRemoteModifiedIds.insert(KCalId(incidence));
-                LOG_TRACE("Have received modified remote incidence id:" << KCalId(incidence).toString());
-            }
-        }
-
-        LOG_DEBUG("Report request finished: received:"
-                  << report->receivedCalendarResources().size() << "iCal blobs containing a total of"
-                  << report->receivedCalendarResources().values().count() << "incidences");
-
-        if (mSyncMode == QuickSync) {
-            sendLocalChanges();
-            return;
-        }
-    } else if (mSyncMode == SlowSync
-               && report->networkError() == QNetworkReply::AuthenticationRequiredError
-               && !mRetriedReport) {
-        // Yahoo sometimes fails the initial request with an authentication error. Let's try once more
-        LOG_WARNING("Retrying REPORT after request failed with QNetworkReply::AuthenticationRequiredError");
-        mRetriedReport = true;
-        sendReportRequest();
-        return;
-    }
-    emitFinished(report->errorCode(), report->errorString());
-}
-
-void NotebookSyncAgent::additionalReportRequestFinished()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    Report *report = qobject_cast<Report*>(sender());
-    mRequests.remove(report);
-    report->deleteLater();
-
-    if (report->errorCode() == Buteo::SyncResults::NO_ERROR) {
-        mReceivedCalendarResources.append(report->receivedCalendarResources().values());
-        LOG_DEBUG("Additional report request finished: received:"
-                  << report->receivedCalendarResources().size() << "iCal blobs containing a total of"
-                  << report->receivedCalendarResources().values().count() << "incidences");
-        LOG_DEBUG("Have received" << mReceivedCalendarResources.count() << "incidences in total!");
-        emitFinished(Buteo::SyncResults::NO_ERROR, QStringLiteral("Finished requests for %1").arg(mNotebook->account()));
-        return;
-    }
-    emitFinished(report->errorCode(), report->errorString());
-}
-
-void NotebookSyncAgent::nonReportRequestFinished()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    Request *request = qobject_cast<Request*>(sender());
-    if (!request) {
-        emitFinished(Buteo::SyncResults::INTERNAL_ERROR, QStringLiteral("Invalid request object"));
-        return;
-    }
-    mRequests.remove(request);
-
-    if (request->errorCode() != Buteo::SyncResults::NO_ERROR) {
-        LOG_CRITICAL("Aborting sync," << request->command() << "failed" << request->errorString() << "for notebook" << mCalendarPath << "of account:" << mNotebookAccountId);
-        emitFinished(request->errorCode(), request->errorString());
-    } else {
-        Put *putRequest = qobject_cast<Put*>(request);
-        if (putRequest) {
-            QHash<QString, QString> updatedETags = putRequest->updatedETags();
-            Q_FOREACH (const QString &uri, updatedETags.keys()) {
-                mUpdatedETags[uri] = updatedETags[uri];
-            }
-        }
-        if (mRequests.isEmpty()) {
-            finalizeSendingLocalChanges();
-        }
-    }
-    request->deleteLater();
-}
-
-void NotebookSyncAgent::finalizeSendingLocalChanges()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    QStringList hrefsToReload;
-
-    for (int i=0; i<mLocallyInsertedIncidences.count(); i++) {
-        KCalCore::Incidence::Ptr &incidence = mLocallyInsertedIncidences[i];
-        QString href = mServerPath + incidence->uid() + ".ics";
-
-        if (!mUpdatedETags.contains(href)) {
-            LOG_DEBUG("Did not receive ETag for incidence " << KCalId(incidence).toString() << "- will reload from server");
-            if (!hrefsToReload.contains(href)) {
-                hrefsToReload.append(href);
-            }
-        } else {
-            // We still need to save the href of this incidence. Otherwise, processETags
-            // will not be able to identify the incidence on the server during the next sync.
-            // If we set custom properties of an incidence, this will change its modification
-            // time. (We also cannot reset the modification time as it will be automatically
-            // set by the storage backend when the incidence is saved to the database.
-            // (See SqliteStorage::Private::saveIncidences of mkcal.)
-            // As a workaround, add the incidence to mReceivedCalendarResources, which
-            // will write the changes and add the incidence to the sync modifications
-            // database, so the custom property change is not picked up as a local
-            // modification during next sync.
-            LOG_DEBUG("Adding URI to existing incidence:" << KCalId(incidence).toString());
-            incidence->setCustomProperty("buteo", "uri", href);
-            Reader::CalendarResource resource;
-            resource.href = href;
-            resource.incidences = KCalCore::Incidence::List() << incidence;
-            KCalCore::ICalFormat icalFormat;
-            resource.iCalData = icalFormat.toICalString(IncidenceHandler::incidenceToExport(incidence));
-            mReceivedCalendarResources.append(resource);
-        }
-    }
-
-    for (int i=0; i<mLocallyModifiedIncidences.count(); i++) {
-        KCalCore::Incidence::Ptr &incidence = mLocallyModifiedIncidences[i];
-        QString href = incidence->customProperty("buteo", "uri");
-        if (!mUpdatedETags.contains(href)) {
-            LOG_DEBUG("Did not receive ETag for incidence " << KCalId(incidence).toString() << "- will reload from server");
-            if (!hrefsToReload.contains(href)) {
-                hrefsToReload.append(href);
-            }
-        }
-    }
-
-    if (!hrefsToReload.isEmpty()) {
-        Report *report = new Report(mNAManager, mSettings);
-        mRequests.insert(report);
-        connect(report, SIGNAL(finished()), this, SLOT(additionalReportRequestFinished()));
-        report->multiGetEvents(mServerPath, hrefsToReload);
-        return;
-    } else {
-        emitFinished(Buteo::SyncResults::NO_ERROR, QStringLiteral("Finished requests for %1").arg(mNotebook->account()));
-    }
-}
-
-void NotebookSyncAgent::emitFinished(int minorErrorCode, const QString &message)
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    if (mFinished) {
-        return;
-    }
-    mFinished = true;
-    clearRequests();
-
-    emit finished(minorErrorCode, message);
-}
-
-bool NotebookSyncAgent::applyRemoteChanges()
-{
-    NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    if (mSyncMode == SlowSync) {
-        // delete the existing notebook associated with this calendar path, if it exists
-        if (!mNotebookUidToDelete.isEmpty()) {
-            mStorage->loadNotebookIncidences(mNotebookUidToDelete);
-            mKCal::Notebook::Ptr doomedNotebook = mStorage->notebook(mNotebookUidToDelete);
-            if (doomedNotebook) {
-                LOG_DEBUG("Deleting notebook which was queued for deletion:" << mNotebookUidToDelete);
-                if (!mStorage->deleteNotebook(doomedNotebook)) {
-                    LOG_DEBUG("Failed to delete notebook" << mNotebookUidToDelete << "which was marked for clean sync");
-                    return false;
-                }
-            } else {
-                LOG_DEBUG("Failed to find notebook which was queued for deletion:" << mNotebookUidToDelete);
-                return false;
-            }
-        }
-
-        // and create a new one
-        mNotebook = mKCal::Notebook::Ptr(new mKCal::Notebook(mNotebookName, QString()));
-        mNotebook->setAccount(mNotebookAccountId);
-        mNotebook->setPluginName(mPluginName);
-        mNotebook->setSyncProfile(mSyncProfile);
-        mNotebook->setColor(mColor);
-        if (!mStorage->addNotebook(mNotebook)) {
-            LOG_DEBUG("Unable to (re)create notebook" << mNotebookName << "during slow sync for account" << mNotebookAccountId << ":" << mCalendarPath);
-            return false;
-        }
-
-        mDatabase->addRemoteCalendar(mNotebook->uid(), mCalendarPath);
-        LOG_DEBUG("Remote calendar" << mCalendarPath << "mapped to newly created notebook" << mNotebook->uid() << "in OOB db for account" << mNotebook->account());
-    }
-
-    if (!updateIncidences(mReceivedCalendarResources)) {
-        return false;
-    }
-    if (!deleteIncidences(mIncidenceIdsToDelete)) {
-        return false;
-    }
-    return true;
-}
-
-bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, const Reader::CalendarResource &resource, bool *criticalError)
+bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, KCalCore::Incidence::List notebookIncidences, const Reader::CalendarResource &resource, bool *criticalError)
 {
     NOTEBOOK_FUNCTION_CALL_TRACE;
 
     if (incidence.isNull()) {
         return false;
     }
-    if (mLocalDeletedIds.contains(KCalId(incidence))) {
-        LOG_DEBUG("Ignore incidence already deleted locally:" << resource.href);
-        return false;
+
+    // find any existing local incidence which corresponds to the received incidence
+    int matchingIncidenceIdx = findIncidenceMatchingHrefUri(notebookIncidences, resource.href);
+    if (matchingIncidenceIdx >= 0) {
+        LOG_DEBUG("found matching local incidence uid:" << notebookIncidences[matchingIncidenceIdx]->uid() <<
+                  "for remote incidence:" << incidence->uid() << "from resource:" << resource.href << resource.etag);
+        incidence->setUid(notebookIncidences[matchingIncidenceIdx]->uid()); // should not be different...
     }
 
-    // find any existing incidence with this uid
-    mStorage->load(incidence->uid());
     KCalCore::Incidence::Ptr storedIncidence;
     switch (incidence->type()) {
     case KCalCore::IncidenceBase::TypeEvent:
@@ -1017,14 +1074,12 @@ bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, cons
     if (storedIncidence) {
         if (incidence->status() == KCalCore::Incidence::StatusCanceled
                 || incidence->customStatus().compare(QStringLiteral("CANCELLED"), Qt::CaseInsensitive) == 0) {
-            LOG_DEBUG("Queuing existing event for deletion:" << KCalId(incidence).toString()
-                                                             << resource.href
-                                                             << resource.etag);
-            mIncidenceIdsToDelete.insert(KCalId(incidence));
+            LOG_DEBUG("Queuing existing event for deletion:" << storedIncidence->uid() << storedIncidence->recurrenceId().toString()
+                                                             << resource.href << resource.etag);
+            mLocalDeletions.append(LocalDeletion(incidence, resource.etag, resource.href));
         } else {
-            LOG_DEBUG("Updating existing event:" << KCalId(incidence).toString()
-                                                 << resource.href
-                                                 << resource.etag);
+            LOG_DEBUG("Updating existing event:" << storedIncidence->uid() << storedIncidence->recurrenceId().toString()
+                                                 << resource.href << resource.etag);
             storedIncidence->startUpdates();
             IncidenceHandler::prepareImportedIncidence(incidence);
             IncidenceHandler::copyIncidenceProperties(storedIncidence, incidence);
@@ -1042,20 +1097,16 @@ bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, cons
                 }
             }
 
-            storedIncidence->setCustomProperty("buteo", "uri", resource.href);
+            // ensure we set the url and etag as required.
+            setIncidenceHrefUri(storedIncidence, resource.href);
+            setIncidenceETag(storedIncidence, resource.etag);
             storedIncidence->endUpdates();
-
-            // Save the modified incidence so it can be used to check whether there were
-            // local changes on the next sync.
-            mModifiedIncidenceICalData.insert(KCalId(incidence), resource.iCalData);
-
-            // Save the incidence etag.
-            mUpdatedETags[resource.href] = resource.etag;
         }
     } else {
-        LOG_DEBUG("Saving new event:" << KCalId(incidence).toString()
-                                      << resource.href
-                                      << resource.etag);
+        // the new incidence will be either a new persistent occurrence, or a new base-series (or new non-recurring).
+        LOG_DEBUG("Have new incidence:" << incidence->uid() << incidence->recurrenceId().toString()
+                                        << resource.href << resource.etag);
+
         KCalCore::Incidence::Ptr occurrence;
         if (incidence->hasRecurrenceId()) {
             // no dissociated occurrence exists already (ie, it's not an update), so create a new one.
@@ -1073,25 +1124,20 @@ bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, cons
 
             IncidenceHandler::prepareImportedIncidence(incidence);
             IncidenceHandler::copyIncidenceProperties(occurrence, incidence);
-            occurrence->setCustomProperty("buteo", "uri", resource.href);
+            setIncidenceHrefUri(occurrence, resource.href);
+            setIncidenceETag(occurrence, resource.etag);
             if (!mCalendar->addEvent(occurrence.staticCast<KCalCore::Event>(), mNotebook->uid())) {
                 LOG_WARNING("error: could not add dissociated occurrence to calendar");
                 return false;
             }
-
-            // Save the new incidence so it can be discarded from the list of local changes
-            // on the next sync when local changes are sent to the server.
-            mNewRemoteIncidenceIds << KCalId(incidence);
-            mModifiedIncidenceICalData.insert(KCalId(incidence), resource.iCalData);
-            mUpdatedETags[resource.href] = resource.etag;
-            LOG_DEBUG("Added new occurrence incidence:" << KCalId(incidence).toString());
+            LOG_DEBUG("Added new occurrence incidence:" << occurrence->uid() << occurrence->recurrenceId().toString());
             return true;
         }
 
         // just a new event without needing detach.
         IncidenceHandler::prepareImportedIncidence(incidence);
-        incidence->setCustomProperty("buteo", "uri", resource.href);
-        mUpdatedETags[resource.href] = resource.etag;
+        setIncidenceHrefUri(incidence, resource.href);
+        setIncidenceETag(incidence, resource.etag);
 
         bool added = false;
         switch (incidence->type()) {
@@ -1110,12 +1156,9 @@ bool NotebookSyncAgent::updateIncidence(KCalCore::Incidence::Ptr incidence, cons
             return false;
         }
         if (added) {
-            // Save the new incidence so it can be discarded from the list of local changes
-            // on the next sync when local changes are sent to the server.
-            mNewRemoteIncidenceIds << KCalId(incidence);
-            LOG_DEBUG("Added new incidence:" << KCalId(incidence).toString());
+            LOG_DEBUG("Added new incidence:" << incidence->uid() << incidence->recurrenceId().toString());
         } else {
-            LOG_CRITICAL("Unable to add incidence" << KCalId(incidence).toString() << "to notebook" << mNotebook->uid());
+            LOG_CRITICAL("Unable to add incidence" << incidence->uid() << incidence->recurrenceId().toString() << "to notebook" << mNotebook->uid());
             *criticalError = true;
             return false;
         }
@@ -1156,6 +1199,12 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
             continue;
         }
 
+        // load the list of current incidences in the notebook.
+        // later, we will match remote incidences with local ones, based on the URI value.
+        KCalCore::Incidence::List notebookIncidences;
+        mStorage->loadNotebookIncidences(mNotebook->uid());
+        mStorage->allIncidences(&notebookIncidences, mNotebook->uid());
+
         // Each resource is either a single event series (or non-recurring event) OR
         // a list of updated/added persistent exceptions to an existing series.
         // If the resource contains an event series which includes the base incidence,
@@ -1184,10 +1233,10 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
         }
 
         if (parentIndex == -1) {
-            LOG_DEBUG("No parent or base incidence in resource's incidence list, performing direct updates");
+            LOG_DEBUG("No parent or base incidence in resource's incidence list, performing direct updates to persistent occurrences");
             for (int i = 0; i < resource.incidences.size(); ++i) {
                 KCalCore::Incidence::Ptr remoteInstance = resource.incidences[i];
-                updateIncidence(remoteInstance, resource, &criticalError);
+                updateIncidence(remoteInstance, notebookIncidences, resource, &criticalError);
                 if (criticalError) {
                     LOG_WARNING("Error saving updated persistent occurrence of resource" << resource.href << ":" << remoteInstance->recurrenceId().toString());
                     return false;
@@ -1205,8 +1254,9 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
         }
 
         // first save the added/updated base incidence
+        LOG_DEBUG("Saving the added/updated base incidence before saving persistent exceptions:" << resource.incidences[parentIndex]->uid());
         KCalCore::Incidence::Ptr updatedBaseIncidence = resource.incidences[parentIndex];
-        updateIncidence(updatedBaseIncidence, resource, &criticalError); // update the base incidence first.
+        updateIncidence(updatedBaseIncidence, notebookIncidences, resource, &criticalError); // update the base incidence first.
         if (criticalError) {
             LOG_WARNING("Error saving base incidence of resource" << resource.href);
             return false;
@@ -1219,9 +1269,10 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
                 continue; // already handled this one.
             }
 
+            LOG_DEBUG("Now saving a persistent exception:" << resource.incidences[i]->recurrenceId().toString());
             KCalCore::Incidence::Ptr remoteInstance = resource.incidences[i];
             remoteRecurrenceIds.append(remoteInstance->recurrenceId());
-            updateIncidence(remoteInstance, resource, &criticalError);
+            updateIncidence(remoteInstance, notebookIncidences, resource, &criticalError);
             if (criticalError) {
                 LOG_WARNING("Error saving updated persistent occurrence of resource" << resource.href << ":" << remoteInstance->recurrenceId().toString());
                 return false;
@@ -1232,6 +1283,7 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
         for (int i = 0; i < localInstances.size(); ++i) {
             KCalCore::Incidence::Ptr localInstance = localInstances[i];
             if (!remoteRecurrenceIds.contains(localInstance->recurrenceId())) {
+                LOG_DEBUG("Now removing remotely-removed persistent occurrence:" << localInstance->recurrenceId().toString());
                 if (!mCalendar->deleteIncidence(localInstance)) {
                     LOG_WARNING("Error removing remotely deleted persistent occurrence of resource" << resource.href << ":" << localInstance->recurrenceId().toString());
                     return false;
@@ -1243,46 +1295,18 @@ bool NotebookSyncAgent::updateIncidences(const QList<Reader::CalendarResource> &
     return true;
 }
 
-bool NotebookSyncAgent::deleteIncidences(const QSet<KCalId> &incidenceUids)
+bool NotebookSyncAgent::deleteIncidences(KCalCore::Incidence::List deletedIncidences)
 {
     NOTEBOOK_FUNCTION_CALL_TRACE;
-
-    if (incidenceUids.isEmpty() || mCalendarIncidencesBeforeSync.isEmpty()) {
-        return true;
-    }
-    QHash<KCalId, KCalCore::Incidence::Ptr> calendarIncidencesMap;
-    for (int i=0; i<mCalendarIncidencesBeforeSync.count(); i++) {
-        calendarIncidencesMap.insert(KCalId(mCalendarIncidencesBeforeSync[i]), mCalendarIncidencesBeforeSync[i]);
-    }
-    Q_FOREACH (const KCalId &incidenceUid, incidenceUids) {
-        if (calendarIncidencesMap.contains(incidenceUid)) {
-            KCalCore::Incidence::Ptr calendarIncidence = calendarIncidencesMap.take(incidenceUid);
-            switch (calendarIncidence->type()) {
-            case KCalCore::IncidenceBase::TypeEvent:
-                if (!mCalendar->deleteEvent(calendarIncidence.staticCast<KCalCore::Event>())) {
-                    LOG_CRITICAL("Unable to delete Event = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                    return false;
-                }
-                LOG_DEBUG("Deleted Event = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                break;
-            case KCalCore::IncidenceBase::TypeTodo:
-                if (!mCalendar->deleteTodo(calendarIncidence.staticCast<KCalCore::Todo>())) {
-                    LOG_CRITICAL("Unable to delete Todo = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                    return false;
-                }
-                LOG_DEBUG("Deleted Todo = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                break;
-            case KCalCore::IncidenceBase::TypeJournal:
-                if (!mCalendar->deleteJournal(calendarIncidence.staticCast<KCalCore::Journal>())) {
-                    LOG_CRITICAL("Unable to delete Journal = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                    return false;
-                }
-                LOG_DEBUG("Deleted Journal = " << incidenceUid.toString() << calendarIncidence->customProperty("buteo", "uri"));
-                break;
-            default:
-                break;
-            }
+    Q_FOREACH (KCalCore::Incidence::Ptr doomed, deletedIncidences) {
+        mStorage->load(doomed->uid());
+        if (!mCalendar->deleteIncidence(mCalendar->incidence(doomed->uid(), doomed->recurrenceId()))) {
+            LOG_CRITICAL("Unable to delete incidence: " << doomed->uid() << doomed->recurrenceId().toString());
+            return false;
+        } else {
+            LOG_DEBUG("Deleted incidence: " << doomed->uid() << doomed->recurrenceId().toString());
         }
     }
     return true;
 }
+

--- a/src/put.h
+++ b/src/put.h
@@ -33,8 +33,6 @@
 
 #include <incidence.h>
 
-#include <kcalid.h>
-
 class QNetworkAccessManager;
 class Settings;
 
@@ -45,8 +43,8 @@ class Put : public Request
 public:
     explicit Put(QNetworkAccessManager *manager, Settings *settings, QObject *parent = 0);
 
-    void updateEvent(const QString &serverPath, const QString &icalData, const QString &eTag, const QString &uri, const KCalId &kcalId);
-    void createEvent(const QString &serverPath, const QString &icalData, const KCalId &kcalId);
+    void updateEvent(const QString &remoteCalendarPath, const QString &icalData, const QString &eTag, const QString &uri, const QString &localUid);
+    void createEvent(const QString &remoteCalendarPath, const QString &icalData, const QString &localUid);
 
     QHash<QString,QString> updatedETags() const;
 
@@ -54,7 +52,7 @@ private Q_SLOTS:
     void requestFinished();
 
 private:
-    QSet<KCalId> mIdList;
+    QSet<QString> mLocalUidList;
     QHash<QString,QString> mUpdatedETags;
 };
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -117,6 +117,7 @@ void Reader::readResponse()
             }
         }
     }
+
     mResults.insert(QUrl::fromPercentEncoding(resource.href.toLatin1()), resource); // multihash insert.
 }
 

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -68,19 +68,19 @@ Report::Report(QNetworkAccessManager *manager, Settings *settings, QObject *pare
     FUNCTION_CALL_TRACE;
 }
 
-void Report::getAllEvents(const QString &serverPath, const QDateTime &fromDateTime, const QDateTime &toDateTime)
+void Report::getAllEvents(const QString &remoteCalendarPath, const QDateTime &fromDateTime, const QDateTime &toDateTime)
 {
     FUNCTION_CALL_TRACE;
-    sendCalendarQuery(serverPath, fromDateTime, toDateTime, true);
+    sendCalendarQuery(remoteCalendarPath, fromDateTime, toDateTime, true);
 }
 
-void Report::getAllETags(const QString &serverPath, const QDateTime &fromDateTime, const QDateTime &toDateTime)
+void Report::getAllETags(const QString &remoteCalendarPath, const QDateTime &fromDateTime, const QDateTime &toDateTime)
 {
     FUNCTION_CALL_TRACE;
-    sendCalendarQuery(serverPath, fromDateTime, toDateTime, false);
+    sendCalendarQuery(remoteCalendarPath, fromDateTime, toDateTime, false);
 }
 
-void Report::sendCalendarQuery(const QString &serverPath,
+void Report::sendCalendarQuery(const QString &remoteCalendarPath,
                                const QDateTime &fromDateTime,
                                const QDateTime &toDateTime,
                                bool getCalendarData)
@@ -105,36 +105,36 @@ void Report::sendCalendarQuery(const QString &serverPath,
                     "</c:comp-filter>" \
                 "</c:filter>" \
             "</c:calendar-query>";
-    sendRequest(serverPath, requestData);
+    sendRequest(remoteCalendarPath, requestData);
 }
 
-void Report::multiGetEvents(const QString &serverPath, const QStringList &eventIdList)
+void Report::multiGetEvents(const QString &remoteCalendarPath, const QStringList &eventHrefList)
 {
     FUNCTION_CALL_TRACE;
 
-    if (eventIdList.isEmpty()) {
+    if (eventHrefList.isEmpty()) {
         return;
     }
 
     QByteArray requestData = "<c:calendar-multiget xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\">" \
                              "<d:prop><d:getetag /><c:calendar-data /></d:prop>";
-    Q_FOREACH (const QString &eventId , eventIdList) {
+    Q_FOREACH (const QString &eventHref , eventHrefList) {
         requestData.append("<d:href>");
-        requestData.append(eventId.toUtf8());
+        requestData.append(eventHref.toUtf8());
         requestData.append("</d:href>");
     }
     requestData.append("</c:calendar-multiget>");
 
-    sendRequest(serverPath, requestData);
+    sendRequest(remoteCalendarPath, requestData);
  }
 
-void Report::sendRequest(const QString& serverPath, const QByteArray &requestData)
+void Report::sendRequest(const QString &remoteCalendarPath, const QByteArray &requestData)
 {
     FUNCTION_CALL_TRACE;
-    mServerPath = serverPath;
+    mRemoteCalendarPath = remoteCalendarPath;
 
     QNetworkRequest request;
-    prepareRequest(&request, serverPath);
+    prepareRequest(&request, remoteCalendarPath);
     request.setRawHeader("Depth", "1");
     request.setRawHeader("Prefer", "return-minimal");
     request.setHeader(QNetworkRequest::ContentLengthHeader, requestData.length());
@@ -152,7 +152,7 @@ void Report::processResponse()
 {
     FUNCTION_CALL_TRACE;
 
-    LOG_DEBUG("Process REPORT response for server path" << mServerPath);
+    LOG_DEBUG("Process REPORT response for server path" << mRemoteCalendarPath);
 
     if (wasDeleted()) {
         LOG_DEBUG("REPORT request was aborted");

--- a/src/report.h
+++ b/src/report.h
@@ -40,13 +40,13 @@ class Report : public Request
 public:
     explicit Report(QNetworkAccessManager *manager, Settings *settings, QObject *parent = 0);
 
-    void getAllEvents(const QString &serverPath,
+    void getAllEvents(const QString &remoteCalendarPath,
                       const QDateTime &fromDateTime = QDateTime(),
                       const QDateTime &toDateTime = QDateTime());
-    void getAllETags(const QString &serverPath,
+    void getAllETags(const QString &remoteCalendarPath,
                      const QDateTime &fromDateTime = QDateTime(),
                      const QDateTime &toDateTime = QDateTime());
-    void multiGetEvents(const QString &serverPath, const QStringList &eventIdList);
+    void multiGetEvents(const QString &remoteCalendarPath, const QStringList &eventHrefList);
 
     QMultiHash<QString, Reader::CalendarResource> receivedCalendarResources() const;
 
@@ -54,12 +54,12 @@ private Q_SLOTS:
     void processResponse();
 
 private:
-    void sendRequest(const QString &serverPath, const QByteArray &requestData);
-    void sendCalendarQuery(const QString &serverPath,
+    void sendRequest(const QString &remoteCalendarPath, const QByteArray &requestData);
+    void sendCalendarQuery(const QString &remoteCalendarPath,
                            const QDateTime &fromDateTime,
                            const QDateTime &toDateTime,
                            bool getCalendarData);
-    QString mServerPath;
+    QString mRemoteCalendarPath;
     QMultiHash<QString, Reader::CalendarResource> mReceivedResources;
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -98,8 +98,3 @@ QList<Settings::CalendarInfo> Settings::calendars() const
 {
     return mCalendars;
 }
-
-QString Settings::notebookId(const QString &calendarServerPath) const
-{
-    return QString::number(mAccountId) + "-" + calendarServerPath;
-}

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,7 +31,7 @@ class Settings
 {
 public:
     struct CalendarInfo {
-        QString serverPath;
+        QString remotePath;
         QString displayName;
         QString color;
     };
@@ -58,8 +58,6 @@ public:
 
     void setCalendars(const QList<CalendarInfo> &calendars);
     QList<CalendarInfo> calendars() const;
-
-    QString notebookId(const QString &calendarServerPath) const;
 
 private:
     QList<CalendarInfo> mCalendars;

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,7 @@ QT       += network dbus
 
 CONFIG += link_pkgconfig debug console
 PKGCONFIG += buteosyncfw5 libsignon-qt5 accounts-qt5 signon-oauth2plugin \
-             libsailfishkeyprovider libkcalcoren-qt5 libmkcal-qt5 socialcache
+             libsailfishkeyprovider libkcalcoren-qt5 libmkcal-qt5
 
 VER_MAJ = 0
 VER_MIN = 1


### PR DESCRIPTION
This commit removes the dependency on the libsocialcache database
to store:
local notebook to remote calendar mapping
local incidence version to remote etag value
local incidence to remote href uri mapping
spurious local delta due to previous sync

Instead, it now stores:
local notebook to remote calendar mapping in the notebook syncProfile()
remote etag value in local incidence custom property
remote href uri in local incidence custom property

The delta is now calculated per-sync, with custom logic to detect
spurious delta caused by local etag/uri update.

Contributes to MER#916