### PR TITLE
[buteo-sync-plugin-caldav] Fix support for non-Latin1 characters. Contributes to MER#982

### DIFF
--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -261,7 +261,9 @@ QList<Settings::CalendarInfo> CalDavClient::loadCalendars(Accounts::Account *acc
         if (!enabledCalendars.contains(calendarPaths[i])) {
             continue;
         }
-        Settings::CalendarInfo info = { calendarPaths[i], displayNames[i], colors[i] };
+        // the calendar path may be percent-encoded.  Return UTF-8 QString.
+        QString remoteCalendarPath = QUrl::fromPercentEncoding(calendarPaths[i].toUtf8());
+        Settings::CalendarInfo info = { remoteCalendarPath, displayNames[i], colors[i] };
         allCalendarInfo << info;
     }
     return allCalendarInfo;

--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -263,6 +263,10 @@ QList<Settings::CalendarInfo> CalDavClient::loadCalendars(Accounts::Account *acc
         }
         // the calendar path may be percent-encoded.  Return UTF-8 QString.
         QString remoteCalendarPath = QUrl::fromPercentEncoding(calendarPaths[i].toUtf8());
+        if (account->providerName() == QStringLiteral("yahoo")) {
+            // Yahoo! seems to double-percent-encode for some reason
+            remoteCalendarPath = QUrl::fromPercentEncoding(remoteCalendarPath.toUtf8());
+        }
         Settings::CalendarInfo info = { remoteCalendarPath, displayNames[i], colors[i] };
         allCalendarInfo << info;
     }

--- a/src/put.cpp
+++ b/src/put.cpp
@@ -44,7 +44,7 @@ Put::Put(QNetworkAccessManager *manager, Settings *settings, QObject *parent)
 {
 }
 
-void Put::updateEvent(const QString &remoteCalendarPath, const QString &icalData, const QString &eTag, const QString &uri, const QString &localUid)
+void Put::updateEvent(const QString &, const QString &icalData, const QString &eTag, const QString &uri, const QString &localUid)
 {
     FUNCTION_CALL_TRACE;
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -73,7 +73,7 @@ void Reader::readResponse()
     CalendarResource resource;
     while (mReader->readNextStartElement()) {
         if (mReader->name() == "href") {
-            resource.href = mReader->readElementText();
+            resource.href = QUrl::fromPercentEncoding(mReader->readElementText().toLatin1());
         } else if (mReader->name() == "propstat") {
             readPropStat(&resource);
         }
@@ -118,7 +118,7 @@ void Reader::readResponse()
         }
     }
 
-    mResults.insert(QUrl::fromPercentEncoding(resource.href.toLatin1()), resource); // multihash insert.
+    mResults.insert(resource.href, resource); // multihash insert.
 }
 
 void Reader::readPropStat(CalendarResource *resource)

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -125,7 +125,7 @@ void Request::prepareRequest(QNetworkRequest *request, const QString &requestPat
         url.setUserName(mSettings->username());
         url.setPassword(mSettings->password());
     }
-    url.setPath(QUrl::fromPercentEncoding(requestPath.toLatin1()));
+    url.setPath(requestPath);
     request->setUrl(url);
 }
 


### PR DESCRIPTION
The previous commit broke handling of non-Latin1 calendar names.
This commit ensures that we always convert percent-encoded paths
into UTF8 QStrings for in-memory processing (including comparison)
and only perform percent-encoding when we need to perform a request
to a remote service.

Contributes to MER#982