### PR TITLE
[buteo-sync-plugin-caldav] Don't restart daemon in %post. Contributes to MER#1044

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -50,4 +50,4 @@ rm -rf %{buildroot}
 %qmake5_install
 
 %post
-su nemo -c "systemctl --user restart msyncd.service"
+echo "if you manually installed the package, you should invoke 'systemctl --user daemon-reload' and then 'systemctl --user restart msyncd'" || :


### PR DESCRIPTION
This commit ensures that we don't attempt to restart any daemon
via %post install section of .spec file.

Contributes to MER#1044