### PR TITLE
[buteo-sync-plugin-caldav] Abort sync if service is disabled. Contributes to MER#1364

### DIFF
--- a/src/authhandler.cpp
+++ b/src/authhandler.cpp
@@ -81,6 +81,11 @@ bool AuthHandler::init()
         return false;
     }
     mAccount->selectService(srv);
+    if (!mAccount->enabled()) {
+        LOG_WARNING("Service:" << m_accountService << "is not enabled for account:" << mAccount->id());
+        return false;
+    }
+
     mAccount->value(AUTH + SLASH + AUTH_METHOD, val);
     mMethod = val.toString();
     mAccount->value(AUTH + SLASH + MECHANISM, val);


### PR DESCRIPTION
In some circumstances, a sync profile might be triggered even if the
user has disabled the account service associated with that profile.
In this case, the caldav plugin should abort sync.

Contributes to MER#1364
